### PR TITLE
Configuration via environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(reflector VERSION 0.4.6 LANGUAGES CXX)
+project(reflector VERSION 0.5.0 LANGUAGES CXX)
 include(CTest)
 
 if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,4 +150,5 @@ FROM scratch AS runtime
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /src/build/reflector /usr/local/bin/reflector
 ENTRYPOINT ["/usr/local/bin/reflector"]
-CMD ["/etc/reflector/config.toml"]
+# No default argument: with none the reflector configures itself from REFLECTOR_* environment
+# variables. To use a file instead, mount it and pass its path, e.g. `docker run ... <image> /etc/reflector/config.toml`.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ GitHub CLI (`gh`, authenticated) and Docker.
 ./build/reflector [config.toml]
 ```
 
-The default config path is `./config.toml`. The process logs to stdout and shuts down cleanly on `SIGINT` / `SIGTERM`.
+Configuration comes from a TOML file, from environment variables, or from both. With a path argument the file is read and merged with any `REFLECTOR_*` environment variables; with **no argument** the configuration comes entirely from the environment (see [Environment variables](#environment-variables)). The process logs to stdout and shuts down cleanly on `SIGINT` / `SIGTERM`.
 
 ### Runtime privileges
 
@@ -114,14 +114,16 @@ Log out and back in after installing for the group membership to take effect.
 
 ### Run in Docker
 
-Prebuilt multi-arch images are published to `ghcr.io/sbogomolov/reflector`, tagged `latest` and per release version, for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the variant matching the host. The image is a single static binary on `scratch` — no shell, no package manager. Its entrypoint is the reflector, with `/etc/reflector/config.toml` as the default argument, so mount your config there.
+Prebuilt multi-arch images are published to `ghcr.io/sbogomolov/reflector`, tagged `latest` and per release version, for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the variant matching the host. The image is a single static binary on `scratch` — no shell, no package manager. Its entrypoint is the reflector with no default argument, so it configures itself from `REFLECTOR_*` [environment variables](#environment-variables); pass a config file path to use a file instead.
 
-Because the reflector captures at L2 on each interface, the container must be **on the real segments it bridges**, not on a default NAT bridge network (which would hide that traffic from it). On a Linux host, `--network host` is the simplest way:
+Because the reflector captures at L2 on each interface, the container must be **on the real segments it bridges**, not on a default NAT bridge network (which would hide that traffic from it). On a Linux host, `--network host` is the simplest way. Configure it with `-e` variables:
 
 ```sh
 docker run --rm \
     --network host \
-    -v /path/to/config.toml:/etc/reflector/config.toml:ro \
+    -e REFLECTOR_TV_SOURCE_IF=eth0 \
+    -e REFLECTOR_TV_TARGET_IF=eth1 \
+    -e REFLECTOR_TV_MDNS=true \
     ghcr.io/sbogomolov/reflector:latest
 ```
 
@@ -131,18 +133,20 @@ docker run --rm \
 docker run --rm \
     --network host \
     --cap-drop ALL --cap-add NET_RAW \
-    -v /path/to/config.toml:/etc/reflector/config.toml:ro \
+    -e REFLECTOR_TV_SOURCE_IF=eth0 \
+    -e REFLECTOR_TV_TARGET_IF=eth1 \
+    -e REFLECTOR_TV_MDNS=true \
     ghcr.io/sbogomolov/reflector:latest
 ```
 
-To keep it running as a service, drop `--rm` and run it detached with a restart policy:
+To use a config file instead of (or alongside) the environment, mount it and pass its path as the argument. This form also shows running it as a service — `-d` with a restart policy:
 
 ```sh
 docker run -d --name reflector --restart unless-stopped \
     --network host \
     --cap-drop ALL --cap-add NET_RAW \
     -v /path/to/config.toml:/etc/reflector/config.toml:ro \
-    ghcr.io/sbogomolov/reflector:latest
+    ghcr.io/sbogomolov/reflector:latest /etc/reflector/config.toml
 ```
 
 Logs are timestamped in UTC by default; pass `-e TZ=Europe/Berlin` (any zoneinfo name) for local time — the zoneinfo database is bundled in the image.
@@ -162,7 +166,7 @@ ssdp      = true         # enable SSDP, disabled by default
 dial      = true         # enable the DIAL proxy, disabled by default
 ```
 
-Mount the config to `/etc/reflector/config.toml`. For the RouterOS side — enabling container mode, creating the `veth`s, and attaching each to its VLAN — see MikroTik's [Container documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/84901929/Container).
+On RouterOS, setting the container's environment variables is usually easier than mounting a file: the entry above becomes `REFLECTOR_TV_SOURCE_IF=veth-lan`, `REFLECTOR_TV_TARGET_IF=veth-iot`, `REFLECTOR_TV_MAC=B0:37:95:C5:60:BE`, `REFLECTOR_TV_WOL=true`, and so on (see [Environment variables](#environment-variables)). To use the file instead, mount it to `/etc/reflector/config.toml` and set that path as the container's command argument. For the RouterOS side — enabling container mode, creating the `veth`s, and attaching each to its VLAN — see MikroTik's [Container documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/84901929/Container).
 
 ## Configuration
 
@@ -184,6 +188,28 @@ address_family = "default"       # optional; default | dual | ipv4 | ipv6 (defau
 ```
 
 An entry must enable at least one protocol and expands into one reflector per enabled protocol, all sharing the entry's interfaces, `mac`, and `address_family`. The same shape serves a single device (set `mac`) or a whole network (omit `mac`). No IP addresses ever appear in the config. `dial` is not a separate reflector — it augments the entry's SSDP reflector with the DIAL application proxy (so it requires `ssdp`; see [DIAL](#dial)).
+
+### Environment variables
+
+Every setting can also come from the environment, which is convenient for containers and RouterOS where mounting a file is awkward. A file argument is then optional; with none, the environment is the whole configuration. Variables are named `REFLECTOR_<TAG>_<PARAM>`:
+
+- `<TAG>` ties one entry's parameters together — any alphanumeric string (`1`, `2`, `TV`, …). It also becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
+- `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MAC`, `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
+
+The only global is `REFLECTOR_LOG_LEVEL`, so `LOG` is a reserved tag. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The `[tv]` entry above looks like this in the environment:
+
+```sh
+REFLECTOR_LOG_LEVEL=info
+REFLECTOR_TV_SOURCE_IF=en0
+REFLECTOR_TV_TARGET_IF=lo0
+REFLECTOR_TV_MAC=B0:37:95:C5:60:BE
+REFLECTOR_TV_WOL=true
+REFLECTOR_TV_MDNS=true
+REFLECTOR_TV_SSDP=true
+REFLECTOR_TV_DIAL=true
+```
+
+When a file and environment variables are both given they are merged: each contributes entries to one combined configuration, and `REFLECTOR_LOG_LEVEL` overrides the file's `log_level`. The [duplicate detection](#duplicate-detection) below applies across both sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all rejected at startup.
 
 ### The `mac` field
 
@@ -225,7 +251,7 @@ It is a **terminating HTTP reverse proxy**. When a DIAL `LOCATION` (in a relayed
 
 ### Duplicate detection
 
-Entry names are unique (TOML rejects duplicate table names). Beyond that, two entries that enable the same protocol are rejected as a duplicate of that protocol only when they could reflect the same packet twice: same `source_if`, same `target_if`, overlapping MAC selection, overlapping address-family handling, and — for WoL — at least one shared port. MAC selection overlaps when both entries set the same `mac`, or when either omits `mac` (any device). Address-family handling overlaps when both can handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual` overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that enable *different* protocols, coexist.
+Entry names must be unique across the file and the environment — a name that appears twice (including the same name from both sources) is rejected at startup. Beyond that, two entries that enable the same protocol are rejected as a duplicate of that protocol only when they could reflect the same packet twice: same `source_if`, same `target_if`, overlapping MAC selection, overlapping address-family handling, and — for WoL — at least one shared port. MAC selection overlaps when both entries set the same `mac`, or when either omits `mac` (any device). Address-family handling overlaps when both can handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual` overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that enable *different* protocols, coexist.
 
 ## Tests
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include "reflector/application.h"
-#include "reflector/config.h"
+#include "reflector/config/config.h"
 #include "reflector/logger.h"
 
 #include <cstdio>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,10 +5,46 @@
 #include <cstdio>
 #include <csignal>
 #include <exception>
+#include <optional>
+#include <string>
+#include <string_view>
 #include <tuple>
 #include <unistd.h>
+#include <vector>
+
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#else
+// Provided by libc. Declared at global scope (not inside the anonymous namespace, where it would
+// become an undefined internal-linkage symbol) and extern "C" so it binds to the libc symbol.
+extern "C" char** environ;
+#endif
 
 namespace {
+// The process environment as a NULL-terminated array of "KEY=VALUE" strings.
+char** Environment() noexcept {
+#if defined(__APPLE__)
+    return *_NSGetEnviron();
+#else
+    return environ;
+#endif
+}
+
+// Collects the environment into key/value views (split on the first '='). The views borrow the
+// environ strings, which live for the whole process, so they stay valid through Config::Load.
+std::vector<reflector::EnvVar> GatherEnvironment() {
+    std::vector<reflector::EnvVar> vars;
+    for (char** entry = Environment(); entry != nullptr && *entry != nullptr; ++entry) {
+        const std::string_view text{*entry};
+        const auto eq = text.find('=');
+        if (eq == std::string_view::npos) {
+            continue;
+        }
+        vars.push_back({text.substr(0, eq), text.substr(eq + 1)});
+    }
+    return vars;
+}
+
 volatile std::sig_atomic_t g_stop_requested = 0;
 // The write end of Application's signal-wakeup self-pipe, or -1 until PrepareSignalWakeup sets it. Writing
 // one byte breaks the dispatcher's blocking poll at once so shutdown doesn't wait up to a poll interval.
@@ -43,10 +79,24 @@ int Run(int argc, char* argv[]) {
         return 2;
     }
 
-    const auto* config_path = argc == 2 ? argv[1] : "config.toml";
-    auto config = reflector::Config::FromFile(config_path);
+    // A config file is optional: with no argument, the configuration comes entirely from
+    // REFLECTOR_* environment variables. When given, the file and the environment are merged.
+    std::optional<std::string> file_contents;
+    if (argc == 2) {
+        auto contents = reflector::Config::ReadFileToString(argv[1]);
+        if (!contents) {
+            logger.Error("Cannot read configuration file: {}", contents.error());
+            return 1;
+        }
+        file_contents = *std::move(contents);
+    }
+
+    const auto env_vars = GatherEnvironment();
+    const std::optional<std::string_view> toml_text =
+        file_contents ? std::optional<std::string_view>{*file_contents} : std::nullopt;
+    auto config = reflector::Config::Load(toml_text, env_vars);
     if (!config) {
-        logger.Error("Cannot read configuration file: {}", config.error());
+        logger.Error("Invalid configuration: {}", config.error());
         return 1;
     }
 

--- a/src/reflector/CMakeLists.txt
+++ b/src/reflector/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(reflector STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/default_address_monitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checksum.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dial_proxy.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_family_reflector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/event_loop_dispatcher.cpp
@@ -28,3 +27,5 @@ reflector_configure_project_target(reflector)
 target_include_directories(reflector PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(reflector PRIVATE tomlplusplus::tomlplusplus)
 target_compile_definitions(reflector PRIVATE TOML_EXCEPTIONS=0)
+
+add_subdirectory(config)

--- a/src/reflector/application.h
+++ b/src/reflector/application.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "address_monitor.h"
-#include "config.h"
+#include "config/config.h"
 #include "default_packet_dispatcher.h"
 #include "dispatcher.h"
 #include "interface.h"

--- a/src/reflector/config.cpp
+++ b/src/reflector/config.cpp
@@ -21,17 +21,6 @@ std::string_view ToStringView(const toml::key& key) {
     return std::string_view{key.data(), key.length()};
 }
 
-std::expected<std::string_view, Error> ReadStringField(const toml::node& field_node,
-        std::string_view section, std::string_view field_name) {
-    const auto field_value = field_node.value<std::string_view>();
-    if (!field_value) {
-        // The key is present (we only reach here while iterating existing keys); it just
-        // isn't a string. Absent required fields are caught later by the config's Verify().
-        return std::unexpected(Error{"{} {} must be a string", section, field_name});
-    }
-    return *field_value;
-}
-
 std::expected<LogLevel, Error> LogLevelFromString(std::string_view s) {
     const auto lower = AsciiToLower(s);
     if (lower == "debug") return LogLevel::Debug;
@@ -130,12 +119,78 @@ std::optional<Error> AppendConfig(std::vector<ConfigType>& configs, ConfigType c
     return std::nullopt;
 }
 
-// Reads one [name] entry and appends a reflector config for each protocol it enables. The entry's
-// shared fields (mac, source_if, target_if, address_family) flow to every enabled protocol; for a
-// real device the one mac is both the WoL target and the mDNS/SSDP frame source.
-std::optional<Error> ReadEntry(std::string_view name, const toml::table& table,
+// A single reflector entry's fields, addressed by their lowercase config key. ReadEntry consumes
+// this interface rather than a toml::table directly, so the field parsing and validation are shared
+// and independent of where the values come from: a source only surfaces the fields it holds and
+// hands back each one as the type that field expects (string, bool, or a port list). TomlSource is
+// the only backend today; the interface is the seam an alternative source plugs into.
+class ConfigSource {
+public:
+    ConfigSource() = default;
+    ConfigSource(const ConfigSource&) = delete;
+    ConfigSource& operator=(const ConfigSource&) = delete;
+    virtual ~ConfigSource() = default;
+
+    // The entry's display name (for TomlSource, its table key), used in errors and as the label.
+    [[nodiscard]] virtual std::string_view Name() const = 0;
+    // The field keys present in this entry, so the caller can dispatch known fields and reject unknown ones.
+    [[nodiscard]] virtual std::vector<std::string_view> Keys() const = 0;
+    // The three value shapes reflector fields reduce to. `key` is always one returned by Keys().
+    [[nodiscard]] virtual std::expected<std::string_view, Error> GetString(std::string_view key) const = 0;
+    [[nodiscard]] virtual std::expected<bool, Error> GetBool(std::string_view key) const = 0;
+    [[nodiscard]] virtual std::expected<std::vector<uint16_t>, Error> GetPorts(std::string_view key) const = 0;
+};
+
+// --- TOML backend: extract field values from a parsed toml::table ---
+
+class TomlSource final : public ConfigSource {
+public:
+    TomlSource(std::string_view name, const toml::table& table) noexcept : name_{name}, table_{&table} {}
+
+    [[nodiscard]] std::string_view Name() const override { return name_; }
+
+    [[nodiscard]] std::vector<std::string_view> Keys() const override {
+        std::vector<std::string_view> keys;
+        keys.reserve(table_->size());
+        for (const auto& [key, node] : *table_) {
+            (void)node;
+            keys.emplace_back(ToStringView(key));
+        }
+        return keys;
+    }
+
+    [[nodiscard]] std::expected<std::string_view, Error> GetString(std::string_view key) const override {
+        const auto value = table_->get(key)->value<std::string_view>();
+        if (!value) {
+            return std::unexpected(Error{"entry \"{}\" {} must be a string", name_, key});
+        }
+        return *value;
+    }
+
+    [[nodiscard]] std::expected<bool, Error> GetBool(std::string_view key) const override {
+        const auto value = table_->get(key)->value<bool>();
+        if (!value) {
+            return std::unexpected(Error{"entry \"{}\" {} must be a boolean", name_, key});
+        }
+        return *value;
+    }
+
+    [[nodiscard]] std::expected<std::vector<uint16_t>, Error> GetPorts(std::string_view key) const override {
+        return ReadPorts(*table_->get(key));
+    }
+
+private:
+    std::string_view name_;
+    const toml::table* table_;
+};
+
+// Reads one entry from any source and appends a reflector config for each protocol it enables. The
+// entry's shared fields (mac, source_if, target_if, address_family) flow to every enabled protocol;
+// for a real device the one mac is both the WoL target and the mDNS/SSDP frame source.
+std::optional<Error> ReadEntry(const ConfigSource& source,
         std::vector<WolConfig>& wol_configs, std::vector<MdnsConfig>& mdns_configs,
         std::vector<SsdpConfig>& ssdp_configs) {
+    const auto name = source.Name();
     std::string source_if;
     std::string target_if;
     std::optional<MacAddress> mac;
@@ -146,22 +201,21 @@ std::optional<Error> ReadEntry(std::string_view name, const toml::table& table,
     bool dial = false;
     AddressFamily address_family = AddressFamily::Default;
 
-    for (const auto& [field_key, field_node] : table) {
-        const auto field_name = ToStringView(field_key);
+    for (const auto field_name : source.Keys()) {
         if (field_name == "source_if") {
-            auto value = ReadStringField(field_node, "entry", field_name);
+            auto value = source.GetString(field_name);
             if (!value) {
                 return std::move(value).error();
             }
             source_if = *value;
         } else if (field_name == "target_if") {
-            auto value = ReadStringField(field_node, "entry", field_name);
+            auto value = source.GetString(field_name);
             if (!value) {
                 return std::move(value).error();
             }
             target_if = *value;
         } else if (field_name == "mac") {
-            auto value = ReadStringField(field_node, "entry", field_name);
+            auto value = source.GetString(field_name);
             if (!value) {
                 return std::move(value).error();
             }
@@ -171,16 +225,16 @@ std::optional<Error> ReadEntry(std::string_view name, const toml::table& table,
             }
             mac = *parsed;
         } else if (field_name == "wol_ports") {
-            auto ports = ReadPorts(field_node);
+            auto ports = source.GetPorts(field_name);
             if (!ports) {
                 return std::move(ports).error();
             }
             wol_ports = std::move(*ports);
         } else if (field_name == "wol" || field_name == "mdns" || field_name == "ssdp"
                 || field_name == "dial") {
-            const auto flag = field_node.value<bool>();
+            auto flag = source.GetBool(field_name);
             if (!flag) {
-                return Error{"entry \"{}\" {} must be a boolean", name, field_name};
+                return std::move(flag).error();
             }
             if (field_name == "wol") {
                 wol = *flag;
@@ -192,9 +246,9 @@ std::optional<Error> ReadEntry(std::string_view name, const toml::table& table,
                 dial = *flag;
             }
         } else if (field_name == "address_family") {
-            const auto value = field_node.value<std::string_view>();
+            auto value = source.GetString(field_name);
             if (!value) {
-                return Error{"entry \"{}\" address_family must be a string", name};
+                return std::move(value).error();
             }
             auto parsed = AddressFamilyFromString("entry", *value);
             if (!parsed) {
@@ -358,8 +412,8 @@ std::expected<Config, Error> Config::FromString(std::string_view str) {
         // A top-level table is a reflector entry (its key is the entry name); the lone known scalar
         // is log_level; any other top-level scalar is a mistyped setting.
         if (const auto* entry_table = value.as_table()) {
-            if (auto error = ReadEntry(key_name, *entry_table,
-                    config.wol_configs_, config.mdns_configs_, config.ssdp_configs_)) {
+            const TomlSource source{key_name, *entry_table};
+            if (auto error = ReadEntry(source, config.wol_configs_, config.mdns_configs_, config.ssdp_configs_)) {
                 return std::unexpected(*std::move(error));
             }
         } else if (key_name == "log_level") {

--- a/src/reflector/config.cpp
+++ b/src/reflector/config.cpp
@@ -5,11 +5,16 @@
 #include <toml++/toml.hpp>
 
 #include <algorithm>
+#include <charconv>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <ios>
+#include <map>
 #include <optional>
+#include <ranges>
+#include <span>
 #include <string>
 #include <system_error>
 
@@ -85,9 +90,8 @@ bool AddressFamiliesOverlap(AddressFamily lhs, AddressFamily rhs) noexcept {
 // Verify one reflector config and reject it if it duplicates an already-accepted one of the same
 // protocol, then append it. Two rules collide when they could reflect the same captured packet:
 // overlapping MAC selection, same source_if and target_if, and overlapping address family (WoL also
-// requires an overlapping port). Names are not checked here: each config's name is its entry's TOML
-// table key, and TOML forbids duplicate table keys, so every entry — and thus every config — has a
-// unique name already (see Config::FromString).
+// requires an overlapping port). Names are not checked here: ConfigAccumulator::AddEntry rejects
+// duplicate entry names across every source before an entry's configs are appended.
 template <typename ConfigType>
 std::optional<Error> AppendConfig(std::vector<ConfigType>& configs, ConfigType config, std::string_view protocol) {
     if (auto error = config.Verify()) {
@@ -120,10 +124,10 @@ std::optional<Error> AppendConfig(std::vector<ConfigType>& configs, ConfigType c
 }
 
 // A single reflector entry's fields, addressed by their lowercase config key. ReadEntry consumes
-// this interface rather than a toml::table directly, so the field parsing and validation are shared
-// and independent of where the values come from: a source only surfaces the fields it holds and
-// hands back each one as the type that field expects (string, bool, or a port list). TomlSource is
-// the only backend today; the interface is the seam an alternative source plugs into.
+// this interface so the field parsing and validation are shared and independent of where the values
+// come from: a source only surfaces the fields it holds and hands back each one as the type that
+// field expects (string, bool, or a port list). TomlSource reads a parsed toml::table; EnvSource
+// reads REFLECTOR_* environment variables, coercing their string values to the expected types.
 class ConfigSource {
 public:
     ConfigSource() = default;
@@ -131,7 +135,7 @@ public:
     ConfigSource& operator=(const ConfigSource&) = delete;
     virtual ~ConfigSource() = default;
 
-    // The entry's display name (for TomlSource, its table key), used in errors and as the label.
+    // The entry's display name (TOML table key, or env tag / NAME), used in errors and as the label.
     [[nodiscard]] virtual std::string_view Name() const = 0;
     // The field keys present in this entry, so the caller can dispatch known fields and reject unknown ones.
     [[nodiscard]] virtual std::vector<std::string_view> Keys() const = 0;
@@ -150,13 +154,10 @@ public:
     [[nodiscard]] std::string_view Name() const override { return name_; }
 
     [[nodiscard]] std::vector<std::string_view> Keys() const override {
-        std::vector<std::string_view> keys;
-        keys.reserve(table_->size());
-        for (const auto& [key, node] : *table_) {
-            (void)node;
-            keys.emplace_back(ToStringView(key));
-        }
-        return keys;
+        // toml++'s iterator pair isn't tuple-like, so std::views::keys doesn't apply; transform .first.
+        return *table_
+            | std::views::transform([](const auto& entry) { return ToStringView(entry.first); })
+            | std::ranges::to<std::vector<std::string_view>>();
     }
 
     [[nodiscard]] std::expected<std::string_view, Error> GetString(std::string_view key) const override {
@@ -182,6 +183,77 @@ public:
 private:
     std::string_view name_;
     const toml::table* table_;
+};
+
+// --- Environment backend: extract field values from REFLECTOR_<tag>_<param> strings ---
+
+using EnvParams = std::map<std::string, std::string, std::less<>>;
+
+// Environment values are strings, so a boolean must be spelled out. true/false mirror TOML; 1/0 are
+// accepted too since they are the natural booleans for shell/Docker env files.
+std::expected<bool, Error> ParseEnvBool(std::string_view name, std::string_view key, std::string_view value) {
+    const auto lower = AsciiToLower(value);
+    if (lower == "true" || lower == "1") {
+        return true;
+    }
+    if (lower == "false" || lower == "0") {
+        return false;
+    }
+    return std::unexpected(Error{"entry \"{}\" {} must be true/false or 1/0; got \"{}\"", name, key, value});
+}
+
+// Environment arrays are comma-separated (e.g. "7,9"), since env vars can't hold a TOML array.
+std::expected<std::vector<uint16_t>, Error> ParseEnvPorts(std::string_view name, std::string_view value) {
+    std::vector<uint16_t> ports;
+    for (size_t pos = 0; pos <= value.size();) {
+        const auto comma = value.find(',', pos);
+        const auto end = comma == std::string_view::npos ? value.size() : comma;
+        auto token = value.substr(pos, end - pos);
+        const auto first = token.find_first_not_of(" \t");
+        const auto last = token.find_last_not_of(" \t");
+        token = first == std::string_view::npos ? std::string_view{} : token.substr(first, last - first + 1);
+        if (token.empty()) {
+            return std::unexpected(Error{"entry \"{}\" wol_ports has an empty entry in \"{}\"", name, value});
+        }
+        uint16_t port = 0;
+        const auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), port);
+        if (ec != std::errc{} || ptr != token.data() + token.size()) {
+            return std::unexpected(Error{"entry \"{}\" wol_ports entry is not a valid port: \"{}\"", name, token});
+        }
+        ports.push_back(port);
+        if (comma == std::string_view::npos) {
+            break;
+        }
+        pos = comma + 1;
+    }
+    return ports;
+}
+
+class EnvSource final : public ConfigSource {
+public:
+    EnvSource(std::string name, EnvParams params) : name_{std::move(name)}, params_{std::move(params)} {}
+
+    [[nodiscard]] std::string_view Name() const override { return name_; }
+
+    [[nodiscard]] std::vector<std::string_view> Keys() const override {
+        return params_ | std::views::keys | std::ranges::to<std::vector<std::string_view>>();
+    }
+
+    [[nodiscard]] std::expected<std::string_view, Error> GetString(std::string_view key) const override {
+        return std::string_view{params_.find(key)->second};
+    }
+
+    [[nodiscard]] std::expected<bool, Error> GetBool(std::string_view key) const override {
+        return ParseEnvBool(name_, key, params_.find(key)->second);
+    }
+
+    [[nodiscard]] std::expected<std::vector<uint16_t>, Error> GetPorts(std::string_view key) const override {
+        return ParseEnvPorts(name_, params_.find(key)->second);
+    }
+
+private:
+    std::string name_;
+    EnvParams params_;
 };
 
 // Reads one entry from any source and appends a reflector config for each protocol it enables. The
@@ -302,6 +374,130 @@ std::optional<Error> ReadEntry(const ConfigSource& source,
     return std::nullopt;
 }
 
+// Accumulates reflector entries (and the optional log level) from one or more sources. Entry names
+// must be unique across every source. Sources are applied in order and the last log level set wins,
+// which is how the environment overrides the file's log_level.
+struct ConfigAccumulator {
+    std::vector<WolConfig> wol;
+    std::vector<MdnsConfig> mdns;
+    std::vector<SsdpConfig> ssdp;
+    std::optional<LogLevel> log_level;
+    std::vector<std::string> entry_names;
+
+    std::optional<Error> AddEntry(const ConfigSource& source) {
+        const auto name = source.Name();
+        if (std::ranges::find(entry_names, name) != entry_names.end()) {
+            return Error{"duplicate entry name \"{}\"", name};
+        }
+        entry_names.emplace_back(name);
+        return ReadEntry(source, wol, mdns, ssdp);
+    }
+};
+
+std::optional<Error> ApplyToml(ConfigAccumulator& acc, std::string_view str) {
+    auto parsed = toml::parse(str);
+    if (!parsed) {
+        const auto& err = parsed.error();
+        const auto& src = err.source();
+        return Error{"invalid configuration at line {}, column {}: {}",
+            src.begin.line, src.begin.column, err.description()};
+    }
+
+    const auto root_table = std::move(parsed).table();
+    for (const auto& [key, value] : root_table) {
+        const auto key_name = ToStringView(key);
+        // A top-level table is a reflector entry (its key is the entry name); the lone known scalar
+        // is log_level; any other top-level scalar is a mistyped setting.
+        if (const auto* entry_table = value.as_table()) {
+            const TomlSource source{key_name, *entry_table};
+            if (auto error = acc.AddEntry(source)) {
+                return error;
+            }
+        } else if (key_name == "log_level") {
+            const auto field_value = value.value<std::string_view>();
+            if (!field_value) {
+                return Error{"log_level must be a string"};
+            }
+            auto level = LogLevelFromString(*field_value);
+            if (!level) {
+                return std::move(level).error();
+            }
+            acc.log_level = *level;
+        } else {
+            return Error{"unexpected top-level key: \"{}\" (expected an entry table or log_level)", key_name};
+        }
+    }
+    return std::nullopt;
+}
+
+// A tag is the <tag> in REFLECTOR_<tag>_<param>. Restricting it to alphanumerics keeps the split on
+// the first underscore unambiguous even though parameter names contain underscores (source_if, etc.).
+bool IsAlnumTag(std::string_view tag) noexcept {
+    return !tag.empty() && std::ranges::all_of(tag, [](char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    });
+}
+
+std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> env_vars) {
+    constexpr std::string_view prefix = "REFLECTOR_";
+    constexpr std::string_view log_level_var = "REFLECTOR_LOG_LEVEL";
+
+    std::optional<std::string_view> log_level_value;
+    // tag -> (lowercase param -> value). std::map gives a deterministic (sorted) entry order so that
+    // duplicate-detection errors and tests don't depend on environ ordering.
+    std::map<std::string, EnvParams, std::less<>> tags;
+
+    for (const auto& var : env_vars) {
+        if (!var.key.starts_with(prefix)) {
+            continue;
+        }
+        if (var.key == log_level_var) {
+            log_level_value = var.value;
+            continue;
+        }
+        const auto rest = var.key.substr(prefix.size());
+        const auto underscore = rest.find('_');
+        if (underscore == std::string_view::npos) {
+            return Error{"environment variable \"{}\" is not of the form REFLECTOR_<tag>_<param>", var.key};
+        }
+        const auto tag = rest.substr(0, underscore);
+        const auto param = rest.substr(underscore + 1);
+        if (!IsAlnumTag(tag)) {
+            return Error{"environment variable \"{}\" has an invalid tag \"{}\" (use letters and digits only)", var.key, tag};
+        }
+        if (AsciiToLower(tag) == "log") {
+            return Error{"environment variable \"{}\": \"{}\" is a reserved tag (use REFLECTOR_LOG_LEVEL for the log level)", var.key, tag};
+        }
+        if (param.empty()) {
+            return Error{"environment variable \"{}\" is missing a parameter name after the tag", var.key};
+        }
+        tags[std::string{tag}].insert_or_assign(AsciiToLower(param), std::string{var.value});
+    }
+
+    if (log_level_value) {
+        auto level = LogLevelFromString(*log_level_value);
+        if (!level) {
+            return std::move(level).error();
+        }
+        acc.log_level = *level;
+    }
+
+    for (auto& [tag, params] : tags) {
+        // NAME, when given, becomes the entry name; otherwise the tag doubles as the name. NAME is not
+        // a reflector field, so it never reaches ReadEntry.
+        std::string name = tag;
+        if (const auto it = params.find("name"); it != params.end()) {
+            name = it->second;
+            params.erase(it);
+        }
+        const EnvSource source{std::move(name), std::move(params)};
+        if (auto error = acc.AddEntry(source)) {
+            return error;
+        }
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 namespace reflector {
@@ -370,7 +566,7 @@ std::optional<Error> SsdpConfig::Verify() const {
     return std::nullopt;
 }
 
-std::expected<Config, Error> Config::FromFile(const char* path) {
+std::expected<std::string, Error> Config::ReadFileToString(const char* path) {
     std::ifstream file{path};
     if (!file) {
         return std::unexpected(Error{"cannot open file \"{}\"", path});
@@ -388,53 +584,33 @@ std::expected<Config, Error> Config::FromFile(const char* path) {
         return static_cast<size_t>(file.gcount());
     });
 
-    return FromString(contents);
+    return contents;
 }
 
 std::expected<Config, Error> Config::FromString(std::string_view str) {
-    auto config = Config{};
-    auto parsed = toml::parse(str);
-    if (!parsed) {
-        const auto& err = parsed.error();
-        const auto& src = err.source();
-        return std::unexpected(Error{
-            "invalid configuration at line {}, column {}: {}",
-            src.begin.line, src.begin.column, err.description()});
-    }
+    return Load(str, std::span<const EnvVar>{});
+}
 
-    const auto root_table = std::move(parsed).table();
-    if (root_table.empty()) {
-        return std::unexpected(Error{"invalid configuration"});
-    }
-
-    for (const auto& [key, value] : root_table) {
-        const auto key_name = ToStringView(key);
-        // A top-level table is a reflector entry (its key is the entry name); the lone known scalar
-        // is log_level; any other top-level scalar is a mistyped setting.
-        if (const auto* entry_table = value.as_table()) {
-            const TomlSource source{key_name, *entry_table};
-            if (auto error = ReadEntry(source, config.wol_configs_, config.mdns_configs_, config.ssdp_configs_)) {
-                return std::unexpected(*std::move(error));
-            }
-        } else if (key_name == "log_level") {
-            const auto field_value = value.value<std::string_view>();
-            if (!field_value) {
-                return std::unexpected(Error{"log_level must be a string"});
-            }
-            auto level = LogLevelFromString(*field_value);
-            if (!level) {
-                return std::unexpected(std::move(level).error());
-            }
-            config.log_level_ = *level;
-        } else {
-            return std::unexpected(Error{"unexpected top-level key: \"{}\" (expected an entry table or log_level)", key_name});
+std::expected<Config, Error> Config::Load(std::optional<std::string_view> toml_text,
+        std::span<const EnvVar> env_vars) {
+    ConfigAccumulator acc;
+    if (toml_text) {
+        if (auto error = ApplyToml(acc, *toml_text)) {
+            return std::unexpected(*std::move(error));
         }
     }
+    if (auto error = ApplyEnv(acc, env_vars)) {
+        return std::unexpected(*std::move(error));
+    }
 
+    Config config;
+    config.wol_configs_ = std::move(acc.wol);
+    config.mdns_configs_ = std::move(acc.mdns);
+    config.ssdp_configs_ = std::move(acc.ssdp);
+    config.log_level_ = acc.log_level.value_or(LogLevel::Info);
     if (config.ReflectorCount() == 0) {
         return std::unexpected(Error{"configuration must contain at least one reflector"});
     }
-
     return config;
 }
 

--- a/src/reflector/config.h
+++ b/src/reflector/config.h
@@ -9,6 +9,7 @@
 #include <expected>
 #include <format>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -94,10 +95,25 @@ struct SsdpConfig {
     [[nodiscard]] std::optional<Error> Verify() const;
 };
 
+// One environment variable, split into its name and value (the '=' itself is dropped). Both views
+// reference storage owned by the caller (the process environment, or test fixtures); Config::Load
+// reads them synchronously and copies out anything it keeps.
+struct EnvVar {
+    std::string_view key;
+    std::string_view value;
+};
+
 class Config {
 public:
-    [[nodiscard]] static std::expected<Config, Error> FromFile(const char* path);
+    // Reads a config file into a string. Separated from FromString/Load so the caller (main) can pass
+    // the same text to Load alongside the environment.
+    [[nodiscard]] static std::expected<std::string, Error> ReadFileToString(const char* path);
     [[nodiscard]] static std::expected<Config, Error> FromString(std::string_view str);
+    // The unified entry point: merges an optional TOML document with REFLECTOR_* environment variables
+    // into one configuration. Reflector entries from both sources share the same duplicate detection;
+    // REFLECTOR_LOG_LEVEL overrides the file's log_level. Fails if the merged result has no reflectors.
+    [[nodiscard]] static std::expected<Config, Error> Load(std::optional<std::string_view> toml_text,
+        std::span<const EnvVar> env_vars);
     [[nodiscard]] const std::vector<WolConfig>& WolConfigs() const noexcept { return wol_configs_; }
     [[nodiscard]] const std::vector<MdnsConfig>& MdnsConfigs() const noexcept { return mdns_configs_; }
     [[nodiscard]] const std::vector<SsdpConfig>& SsdpConfigs() const noexcept { return ssdp_configs_; }

--- a/src/reflector/config/CMakeLists.txt
+++ b/src/reflector/config/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(reflector PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/entries.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.cpp
+)

--- a/src/reflector/config/address_family.h
+++ b/src/reflector/config/address_family.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdint>
+#include <format>
+#include <utility>
+
+namespace reflector {
+
+enum class AddressFamily : uint8_t {
+    Default,
+    Dual,
+    IPv4,
+    IPv6,
+};
+
+// Which IP versions a reflector handles. "Uses" = will attempt the family; "Requires" = startup
+// fails if it can't be initialized. Default attempts both but only requires IPv4 (IPv6 is
+// best-effort); Dual requires both; IPv4 / IPv6 use only that one.
+[[nodiscard]] constexpr bool UsesIPv4(AddressFamily family) noexcept {
+    return family != AddressFamily::IPv6;
+}
+[[nodiscard]] constexpr bool UsesIPv6(AddressFamily family) noexcept {
+    return family != AddressFamily::IPv4;
+}
+[[nodiscard]] constexpr bool RequiresIPv4(AddressFamily family) noexcept {
+    return family == AddressFamily::Default || family == AddressFamily::Dual
+        || family == AddressFamily::IPv4;
+}
+[[nodiscard]] constexpr bool RequiresIPv6(AddressFamily family) noexcept {
+    return family == AddressFamily::Dual || family == AddressFamily::IPv6;
+}
+
+} // namespace reflector
+
+template <>
+struct std::formatter<reflector::AddressFamily, char>
+{
+    template <class ParseContext>
+    constexpr ParseContext::iterator parse(ParseContext& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Invalid format args for AddressFamily");
+        }
+
+        return it;
+    }
+
+    template <typename FmtContext>
+    FmtContext::iterator format(reflector::AddressFamily address_family, FmtContext& ctx) const {
+        switch (address_family) {
+        using enum reflector::AddressFamily;
+        case Default: return std::format_to(ctx.out(), "default");
+        case Dual: return std::format_to(ctx.out(), "dual");
+        case IPv4: return std::format_to(ctx.out(), "ipv4");
+        case IPv6: return std::format_to(ctx.out(), "ipv6");
+        }
+
+        std::unreachable();
+    }
+};

--- a/src/reflector/config/config.cpp
+++ b/src/reflector/config/config.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
-#include "mac_address.h"
-#include "util/ascii.h"
+
+#include "reflector/mac_address.h"
+#include "reflector/util/ascii.h"
 
 #include <toml++/toml.hpp>
 
@@ -501,70 +502,6 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
 } // namespace
 
 namespace reflector {
-
-std::optional<Error> WolConfig::Verify() const {
-    if (name.empty()) {
-        return Error{"wol name is not configured"};
-    }
-    if (source_if.empty()) {
-        return Error{"wol source_if is not configured"};
-    }
-    if (target_if.empty()) {
-        return Error{"wol target_if is not configured"};
-    }
-    if (source_if == target_if) {
-        return Error{"wol source_if and target_if must be different: \"{}\"", source_if};
-    }
-    if (ports.empty()) {
-        return Error{"wol ports is empty"};
-    }
-    for (const auto port : ports) {
-        if (port == 0) {
-            return Error{"wol port cannot be 0"};
-        }
-    }
-    auto sorted_ports = ports;
-    std::ranges::sort(sorted_ports);
-    if (const auto it = std::ranges::adjacent_find(sorted_ports); it != sorted_ports.end()) {
-        return Error{"wol ports contains duplicate port: {}", *it};
-    }
-    return std::nullopt;
-}
-
-std::optional<Error> MdnsConfig::Verify() const {
-    if (name.empty()) {
-        return Error{"mdns name is not configured"};
-    }
-    if (source_if.empty()) {
-        return Error{"mdns source_if is not configured"};
-    }
-    if (target_if.empty()) {
-        return Error{"mdns target_if is not configured"};
-    }
-    if (source_if == target_if) {
-        return Error{"mdns source_if and target_if must be different: \"{}\"", source_if};
-    }
-    return std::nullopt;
-}
-
-std::optional<Error> SsdpConfig::Verify() const {
-    if (name.empty()) {
-        return Error{"ssdp name is not configured"};
-    }
-    if (source_if.empty()) {
-        return Error{"ssdp source_if is not configured"};
-    }
-    if (target_if.empty()) {
-        return Error{"ssdp target_if is not configured"};
-    }
-    if (source_if == target_if) {
-        return Error{"ssdp source_if and target_if must be different: \"{}\"", source_if};
-    }
-    if (dial && !UsesIPv4()) {
-        return Error{"ssdp entry \"{}\" enables dial but has no IPv4 family (DIAL is IPv4-only)", name};
-    }
-    return std::nullopt;
-}
 
 std::expected<std::string, Error> Config::ReadFileToString(const char* path) {
     std::ifstream file{path};

--- a/src/reflector/config/config.h
+++ b/src/reflector/config/config.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "entries.h"
+
+#include "reflector/error.h"
+#include "reflector/logger.h"
+
+#include <cstddef>
+#include <expected>
+#include <format>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace reflector {
+
+// One environment variable, split into its name and value (the '=' itself is dropped). Both views
+// reference storage owned by the caller (the process environment, or test fixtures); Config::Load
+// reads them synchronously and copies out anything it keeps.
+struct EnvVar {
+    std::string_view key;
+    std::string_view value;
+};
+
+class Config {
+public:
+    // Reads a config file into a string. Separated from FromString/Load so the caller (main) can pass
+    // the same text to Load alongside the environment.
+    [[nodiscard]] static std::expected<std::string, Error> ReadFileToString(const char* path);
+    [[nodiscard]] static std::expected<Config, Error> FromString(std::string_view str);
+    // The unified entry point: merges an optional TOML document with REFLECTOR_* environment variables
+    // into one configuration. Reflector entries from both sources share the same duplicate detection;
+    // REFLECTOR_LOG_LEVEL overrides the file's log_level. Fails if the merged result has no reflectors.
+    [[nodiscard]] static std::expected<Config, Error> Load(std::optional<std::string_view> toml_text,
+        std::span<const EnvVar> env_vars);
+    [[nodiscard]] const std::vector<WolConfig>& WolConfigs() const noexcept { return wol_configs_; }
+    [[nodiscard]] const std::vector<MdnsConfig>& MdnsConfigs() const noexcept { return mdns_configs_; }
+    [[nodiscard]] const std::vector<SsdpConfig>& SsdpConfigs() const noexcept { return ssdp_configs_; }
+    [[nodiscard]] LogLevel MinLogLevel() const noexcept { return log_level_; }
+
+private:
+    // Test-only: builds a Config programmatically, bypassing TOML parsing.
+    friend class TestConfigBuilder;
+
+    Config() noexcept = default;
+    [[nodiscard]] size_t ReflectorCount() const noexcept {
+        return wol_configs_.size() + mdns_configs_.size() + ssdp_configs_.size();
+    }
+
+    std::vector<WolConfig> wol_configs_;
+    std::vector<MdnsConfig> mdns_configs_;
+    std::vector<SsdpConfig> ssdp_configs_;
+    LogLevel log_level_ = LogLevel::Info;
+};
+
+} // namespace reflector
+
+template <>
+struct std::formatter<reflector::Config, char>
+{
+    template <class ParseContext>
+    constexpr ParseContext::iterator parse(ParseContext& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Invalid format args for Config");
+        }
+
+        return it;
+    }
+
+    template <typename FmtContext>
+    FmtContext::iterator format(const reflector::Config& c, FmtContext& ctx) const
+    {
+        std::format_to(ctx.out(), "{{log_level: {}, wol: [", c.MinLogLevel());
+        bool first = true;
+        for (const auto& wol_config : c.WolConfigs()) {
+            if (first) {
+                first = false;
+            } else {
+                std::format_to(ctx.out(), ", ");
+            }
+            std::format_to(ctx.out(), "{}", wol_config);
+        }
+
+        std::format_to(ctx.out(), "], mdns: [");
+        first = true;
+        for (const auto& mdns_config : c.MdnsConfigs()) {
+            if (first) {
+                first = false;
+            } else {
+                std::format_to(ctx.out(), ", ");
+            }
+            std::format_to(ctx.out(), "{}", mdns_config);
+        }
+
+        std::format_to(ctx.out(), "], ssdp: [");
+        first = true;
+        for (const auto& ssdp_config : c.SsdpConfigs()) {
+            if (first) {
+                first = false;
+            } else {
+                std::format_to(ctx.out(), ", ");
+            }
+            std::format_to(ctx.out(), "{}", ssdp_config);
+        }
+
+        return std::format_to(ctx.out(), "]}}");
+    }
+};

--- a/src/reflector/config/entries.cpp
+++ b/src/reflector/config/entries.cpp
@@ -1,0 +1,72 @@
+#include "entries.h"
+
+#include <algorithm>
+#include <optional>
+
+namespace reflector {
+
+std::optional<Error> WolConfig::Verify() const {
+    if (name.empty()) {
+        return Error{"wol name is not configured"};
+    }
+    if (source_if.empty()) {
+        return Error{"wol source_if is not configured"};
+    }
+    if (target_if.empty()) {
+        return Error{"wol target_if is not configured"};
+    }
+    if (source_if == target_if) {
+        return Error{"wol source_if and target_if must be different: \"{}\"", source_if};
+    }
+    if (ports.empty()) {
+        return Error{"wol ports is empty"};
+    }
+    for (const auto port : ports) {
+        if (port == 0) {
+            return Error{"wol port cannot be 0"};
+        }
+    }
+    auto sorted_ports = ports;
+    std::ranges::sort(sorted_ports);
+    if (const auto it = std::ranges::adjacent_find(sorted_ports); it != sorted_ports.end()) {
+        return Error{"wol ports contains duplicate port: {}", *it};
+    }
+    return std::nullopt;
+}
+
+std::optional<Error> MdnsConfig::Verify() const {
+    if (name.empty()) {
+        return Error{"mdns name is not configured"};
+    }
+    if (source_if.empty()) {
+        return Error{"mdns source_if is not configured"};
+    }
+    if (target_if.empty()) {
+        return Error{"mdns target_if is not configured"};
+    }
+    if (source_if == target_if) {
+        return Error{"mdns source_if and target_if must be different: \"{}\"", source_if};
+    }
+    return std::nullopt;
+}
+
+std::optional<Error> SsdpConfig::Verify() const {
+    if (name.empty()) {
+        return Error{"ssdp name is not configured"};
+    }
+    if (source_if.empty()) {
+        return Error{"ssdp source_if is not configured"};
+    }
+    if (target_if.empty()) {
+        return Error{"ssdp target_if is not configured"};
+    }
+    if (source_if == target_if) {
+        return Error{"ssdp source_if and target_if must be different: \"{}\"", source_if};
+    }
+    if (dial && !UsesIPv4()) {
+        return Error{"ssdp entry \"{}\" enables dial but has no IPv4 family (DIAL is IPv4-only)", name};
+    }
+    return std::nullopt;
+}
+
+} // namespace reflector

--- a/src/reflector/config/entries.h
+++ b/src/reflector/config/entries.h
@@ -1,45 +1,17 @@
 #pragma once
 
-#include "error.h"
-#include "logger.h"
-#include "mac_address.h"
+#include "address_family.h"
 
-#include <cstddef>
+#include "reflector/error.h"
+#include "reflector/mac_address.h"
+
 #include <cstdint>
-#include <expected>
 #include <format>
 #include <optional>
-#include <span>
 #include <string>
-#include <string_view>
-#include <utility>
 #include <vector>
 
 namespace reflector {
-
-enum class AddressFamily : uint8_t {
-    Default,
-    Dual,
-    IPv4,
-    IPv6,
-};
-
-// Which IP versions a reflector handles. "Uses" = will attempt the family; "Requires" = startup
-// fails if it can't be initialized. Default attempts both but only requires IPv4 (IPv6 is
-// best-effort); Dual requires both; IPv4 / IPv6 use only that one.
-[[nodiscard]] constexpr bool UsesIPv4(AddressFamily family) noexcept {
-    return family != AddressFamily::IPv6;
-}
-[[nodiscard]] constexpr bool UsesIPv6(AddressFamily family) noexcept {
-    return family != AddressFamily::IPv4;
-}
-[[nodiscard]] constexpr bool RequiresIPv4(AddressFamily family) noexcept {
-    return family == AddressFamily::Default || family == AddressFamily::Dual
-        || family == AddressFamily::IPv4;
-}
-[[nodiscard]] constexpr bool RequiresIPv6(AddressFamily family) noexcept {
-    return family == AddressFamily::Dual || family == AddressFamily::IPv6;
-}
 
 struct WolConfig {
     std::string name;
@@ -95,73 +67,7 @@ struct SsdpConfig {
     [[nodiscard]] std::optional<Error> Verify() const;
 };
 
-// One environment variable, split into its name and value (the '=' itself is dropped). Both views
-// reference storage owned by the caller (the process environment, or test fixtures); Config::Load
-// reads them synchronously and copies out anything it keeps.
-struct EnvVar {
-    std::string_view key;
-    std::string_view value;
-};
-
-class Config {
-public:
-    // Reads a config file into a string. Separated from FromString/Load so the caller (main) can pass
-    // the same text to Load alongside the environment.
-    [[nodiscard]] static std::expected<std::string, Error> ReadFileToString(const char* path);
-    [[nodiscard]] static std::expected<Config, Error> FromString(std::string_view str);
-    // The unified entry point: merges an optional TOML document with REFLECTOR_* environment variables
-    // into one configuration. Reflector entries from both sources share the same duplicate detection;
-    // REFLECTOR_LOG_LEVEL overrides the file's log_level. Fails if the merged result has no reflectors.
-    [[nodiscard]] static std::expected<Config, Error> Load(std::optional<std::string_view> toml_text,
-        std::span<const EnvVar> env_vars);
-    [[nodiscard]] const std::vector<WolConfig>& WolConfigs() const noexcept { return wol_configs_; }
-    [[nodiscard]] const std::vector<MdnsConfig>& MdnsConfigs() const noexcept { return mdns_configs_; }
-    [[nodiscard]] const std::vector<SsdpConfig>& SsdpConfigs() const noexcept { return ssdp_configs_; }
-    [[nodiscard]] LogLevel MinLogLevel() const noexcept { return log_level_; }
-
-private:
-    // Test-only: builds a Config programmatically, bypassing TOML parsing.
-    friend class TestConfigBuilder;
-
-    Config() noexcept = default;
-    [[nodiscard]] size_t ReflectorCount() const noexcept {
-        return wol_configs_.size() + mdns_configs_.size() + ssdp_configs_.size();
-    }
-
-    std::vector<WolConfig> wol_configs_;
-    std::vector<MdnsConfig> mdns_configs_;
-    std::vector<SsdpConfig> ssdp_configs_;
-    LogLevel log_level_ = LogLevel::Info;
-};
-
 } // namespace reflector
-
-template <>
-struct std::formatter<reflector::AddressFamily, char>
-{
-    template <class ParseContext>
-    constexpr ParseContext::iterator parse(ParseContext& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw std::format_error("Invalid format args for AddressFamily");
-        }
-
-        return it;
-    }
-
-    template <typename FmtContext>
-    FmtContext::iterator format(reflector::AddressFamily address_family, FmtContext& ctx) const {
-        switch (address_family) {
-        using enum reflector::AddressFamily;
-        case Default: return std::format_to(ctx.out(), "default");
-        case Dual: return std::format_to(ctx.out(), "dual");
-        case IPv4: return std::format_to(ctx.out(), "ipv4");
-        case IPv6: return std::format_to(ctx.out(), "ipv6");
-        }
-
-        std::unreachable();
-    }
-};
 
 template <>
 struct std::formatter<reflector::WolConfig, char>
@@ -248,58 +154,5 @@ struct std::formatter<reflector::SsdpConfig, char>
         }
         return std::format_to(ctx.out(), ", source_if: \"{}\", target_if: \"{}\", address_family: {}, dial: {}}}",
             c.source_if, c.target_if, c.address_family, c.dial);
-    }
-};
-
-template <>
-struct std::formatter<reflector::Config, char>
-{
-    template <class ParseContext>
-    constexpr ParseContext::iterator parse(ParseContext& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw std::format_error("Invalid format args for Config");
-        }
-
-        return it;
-    }
-
-    template <typename FmtContext>
-    FmtContext::iterator format(const reflector::Config& c, FmtContext& ctx) const
-    {
-        std::format_to(ctx.out(), "{{log_level: {}, wol: [", c.MinLogLevel());
-        bool first = true;
-        for (const auto& wol_config : c.WolConfigs()) {
-            if (first) {
-                first = false;
-            } else {
-                std::format_to(ctx.out(), ", ");
-            }
-            std::format_to(ctx.out(), "{}", wol_config);
-        }
-
-        std::format_to(ctx.out(), "], mdns: [");
-        first = true;
-        for (const auto& mdns_config : c.MdnsConfigs()) {
-            if (first) {
-                first = false;
-            } else {
-                std::format_to(ctx.out(), ", ");
-            }
-            std::format_to(ctx.out(), "{}", mdns_config);
-        }
-
-        std::format_to(ctx.out(), "], ssdp: [");
-        first = true;
-        for (const auto& ssdp_config : c.SsdpConfigs()) {
-            if (first) {
-                first = false;
-            } else {
-                std::format_to(ctx.out(), ", ");
-            }
-            std::format_to(ctx.out(), "{}", ssdp_config);
-        }
-
-        return std::format_to(ctx.out(), "]}}");
     }
 };

--- a/src/reflector/mdns_reflector.h
+++ b/src/reflector/mdns_reflector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config.h"
+#include "config/config.h"
 #include "dynamic_family_reflector.h"
 #include "ip_address.h"
 #include "link_socket.h"

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config.h"
+#include "config/config.h"
 #include "dial_proxy.h"
 #include "dynamic_family_reflector.h"
 #include "ip_address.h"

--- a/src/reflector/wol_reflector.h
+++ b/src/reflector/wol_reflector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config.h"
+#include "config/config.h"
 #include "family_capability.h"
 #include "link_socket.h"
 #include "mac_address.h"

--- a/tests/application_test.cpp
+++ b/tests/application_test.cpp
@@ -1,6 +1,6 @@
 #include "reflector/application.h"
 
-#include "reflector/config.h"
+#include "reflector/config/config.h"
 #include "reflector/error.h"
 #include "reflector/interface.h"
 #include "reflector/link_socket.h"

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -123,6 +123,20 @@ TEST(ConfigTest, VerifyRejectsDuplicatePorts) {
     EXPECT_TRUE(wol_config.Verify().has_value());
 }
 
+TEST(ConfigTest, VerifyRejectsEmptyPorts) {
+    // Reachable only by a direct caller: the parser defaults ports to {7,9} and rejects an empty
+    // wol_ports array before assignment, so this branch has no TOML/env path.
+    const auto wol_config = WolConfig{
+        .name = "a",
+        .mac = std::nullopt,
+        .source_if = "eth0",
+        .target_if = "eth1",
+        .ports = {},
+    };
+
+    EXPECT_TRUE(wol_config.Verify().has_value());
+}
+
 // --- entry parsing and protocol expansion ---
 
 TEST(ConfigTest, ParsesSingleProtocolEntry) {
@@ -532,6 +546,26 @@ wol = true
 )").has_value());
 }
 
+TEST(ConfigTest, RejectsEmptyNameMdns) {
+    // Same invariant via MdnsConfig::Verify (empty name reaches a different protocol's check).
+    EXPECT_FALSE(Config::FromString(R"(
+[""]
+source_if = "eth0"
+target_if = "eth1"
+mdns = true
+)").has_value());
+}
+
+TEST(ConfigTest, RejectsEmptyNameSsdp) {
+    // Same invariant via SsdpConfig::Verify.
+    EXPECT_FALSE(Config::FromString(R"(
+[""]
+source_if = "eth0"
+target_if = "eth1"
+ssdp = true
+)").has_value());
+}
+
 TEST(ConfigTest, RejectsUnknownEntryField) {
     EXPECT_FALSE(Config::FromString(R"(
 [tv]
@@ -879,6 +913,24 @@ source_if = "eth0"
 target_if = "eth1"
 wol = true
 address_family = "ipv4"
+)").has_value());
+}
+
+TEST(ConfigTest, RejectsDuplicateIpv6OnlyRules) {
+    // Two ipv6-only rules on the same triple collide via the IPv6 disjunct of AddressFamiliesOverlap
+    // (the IPv4 disjunct is false for both) -- the mirror of the default/ipv4 case above.
+    EXPECT_FALSE(Config::FromString(R"(
+[a]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+address_family = "ipv6"
+
+[b]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+address_family = "ipv6"
 )").has_value());
 }
 
@@ -1473,6 +1525,69 @@ TEST(ConfigTest, SsdpFormatterPrintsDial) {
     EXPECT_NE(std::format("{}", ssdp).find("dial: true"), std::string::npos);
 }
 
+TEST(ConfigTest, AddressFamilyFormatter) {
+    EXPECT_EQ(std::format("{}", AddressFamily::Default), "default");
+    EXPECT_EQ(std::format("{}", AddressFamily::Dual), "dual");
+    EXPECT_EQ(std::format("{}", AddressFamily::IPv4), "ipv4");
+    EXPECT_EQ(std::format("{}", AddressFamily::IPv6), "ipv6");
+}
+
+TEST(ConfigTest, WolConfigFormatter) {
+    const auto with_mac = WolConfig{
+        .name = "tv", .mac = *MacAddress::FromString("00:11:22:33:44:55"),
+        .source_if = "eth0", .target_if = "eth1", .ports = {7, 9, 42},
+    };
+    const auto s = std::format("{}", with_mac);
+    EXPECT_NE(s.find("\"tv\""), std::string::npos) << s;
+    EXPECT_NE(s.find("eth0"), std::string::npos) << s;
+    EXPECT_NE(s.find("eth1"), std::string::npos) << s;
+    EXPECT_NE(s.find("ports: ["), std::string::npos) << s;
+    EXPECT_NE(s.find("42"), std::string::npos) << s;
+    EXPECT_EQ(s.find("any"), std::string::npos) << s;  // mac present, so not "any"
+
+    const auto no_mac = WolConfig{.name = "net", .mac = std::nullopt, .source_if = "eth0", .target_if = "eth1"};
+    EXPECT_NE(std::format("{}", no_mac).find("any"), std::string::npos);
+}
+
+TEST(ConfigTest, MdnsConfigFormatter) {
+    const auto mdns = MdnsConfig{
+        .name = "disc", .mac = std::nullopt, .source_if = "lan", .target_if = "iot",
+        .address_family = AddressFamily::IPv6,
+    };
+    const auto s = std::format("{}", mdns);
+    EXPECT_NE(s.find("\"disc\""), std::string::npos) << s;
+    EXPECT_NE(s.find("any"), std::string::npos) << s;   // no mac
+    EXPECT_NE(s.find("ipv6"), std::string::npos) << s;  // address_family rendered
+}
+
+TEST(ConfigTest, SsdpFormatterPrintsMacAndDialFalse) {
+    const auto ssdp = SsdpConfig{
+        .name = "tv", .mac = *MacAddress::FromString("00:11:22:33:44:55"),
+        .source_if = "lan", .target_if = "iot", .dial = false,
+    };
+    const auto s = std::format("{}", ssdp);
+    EXPECT_NE(s.find("dial: false"), std::string::npos) << s;
+    EXPECT_EQ(s.find("any"), std::string::npos) << s;  // mac present
+}
+
+TEST(ConfigTest, ConfigFormatterRendersAllSections) {
+    const auto config = Config::FromString(R"(
+log_level = "warning"
+[tv]
+source_if = "lan"
+target_if = "iot"
+wol = true
+mdns = true
+ssdp = true
+)");
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    const auto s = std::format("{}", *config);
+    EXPECT_NE(s.find("log_level:"), std::string::npos) << s;
+    EXPECT_NE(s.find("wol: ["), std::string::npos) << s;
+    EXPECT_NE(s.find("mdns: ["), std::string::npos) << s;
+    EXPECT_NE(s.find("ssdp: ["), std::string::npos) << s;
+}
+
 TEST(ConfigTest, ParsesSsdpDialFlagFromToml) {
     const auto config = Config::FromString(R"(
 [tv]
@@ -1499,14 +1614,18 @@ ssdp = true
 }
 
 TEST(ConfigTest, RejectsDialWithoutSsdp) {
+    // wol is enabled so the entry passes the "enables no protocol" check and actually reaches the
+    // dial-without-ssdp branch; asserting on "dial" ensures the dial-specific error fired (the
+    // no-protocol message also contains "ssdp", so a "ssdp" assertion would pass via the wrong path).
     const auto config = Config::FromString(R"(
 [tv]
 source_if = "lan"
 target_if = "iot"
+wol = true
 dial = true
 )");
     ASSERT_FALSE(config.has_value());  // dial requires ssdp (rejected at parse, no config appended)
-    EXPECT_NE(config.error().Message().find("ssdp"), std::string::npos) << config.error().Message();
+    EXPECT_NE(config.error().Message().find("dial"), std::string::npos) << config.error().Message();
 }
 
 TEST(ConfigTest, RejectsNonBooleanDial) {

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -1,4 +1,4 @@
-#include "reflector/config.h"
+#include "reflector/config/config.h"
 #include "reflector/logger.h"
 #include "reflector/mac_address.h"
 

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -9,10 +9,13 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <initializer_list>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -36,6 +39,17 @@ target_if = "eth1"
 wol = true
 )";
     return toml;
+}
+
+// Builds an EnvVar list from literal key/value pairs. The views reference the string literals (static
+// storage), so the returned vector stays valid for as long as it lives.
+std::vector<EnvVar> Env(std::initializer_list<std::pair<std::string_view, std::string_view>> vars) {
+    std::vector<EnvVar> env;
+    env.reserve(vars.size());
+    for (const auto& [key, value] : vars) {
+        env.push_back(EnvVar{key, value});
+    }
+    return env;
 }
 
 } // namespace
@@ -376,7 +390,7 @@ wol = true
 )").has_value());
 }
 
-// --- FromFile and malformed input ---
+// --- file reading and malformed input ---
 
 TEST(ConfigTest, RejectsEmptyDocument) {
     EXPECT_FALSE(Config::FromString("").has_value());
@@ -394,17 +408,17 @@ TEST(ConfigTest, MalformedTomlErrorIncludesLineAndColumn) {
     EXPECT_NE(message.find("column"), std::string::npos) << "message: " << message;
 }
 
-TEST(ConfigTest, FromFileMissingFails) {
+TEST(ConfigTest, ReadFileToStringMissingFails) {
     const auto path = MakeTempConfigPath("missing");
 
     std::error_code ec;
     std::filesystem::remove(path, ec);
 
     const auto path_string = path.string();
-    EXPECT_FALSE(Config::FromFile(path_string.c_str()).has_value());
+    EXPECT_FALSE(Config::ReadFileToString(path_string.c_str()).has_value());
 }
 
-TEST(ConfigTest, FromFileParsesConfig) {
+TEST(ConfigTest, ReadsAndParsesFileConfig) {
     const auto path = MakeTempConfigPath("valid");
     {
         std::ofstream file{path};
@@ -419,11 +433,13 @@ wol = true
     }
 
     const auto path_string = path.string();
-    const auto config = Config::FromFile(path_string.c_str());
+    const auto contents = Config::ReadFileToString(path_string.c_str());
 
     std::error_code ec;
     std::filesystem::remove(path, ec);
 
+    ASSERT_TRUE(contents.has_value()) << contents.error().Message();
+    const auto config = Config::FromString(*contents);
     ASSERT_TRUE(config.has_value()) << config.error().Message();
     ASSERT_EQ(config->WolConfigs().size(), 1);
 
@@ -1518,6 +1534,377 @@ dial = true
 )");
     ASSERT_FALSE(config.has_value());
     EXPECT_NE(config.error().Message().find("dial"), std::string::npos) << config.error().Message();
+}
+
+// --- environment-variable configuration (Config::Load) ---
+
+TEST(ConfigTest, EnvParsesSingleWolEntry) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_NAME", "tv"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_MAC", "B0:37:95:C5:60:BE"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    ASSERT_EQ(config->WolConfigs().size(), 1u);
+    const auto& wol = config->WolConfigs().front();
+    EXPECT_EQ(wol.name, "tv");
+    EXPECT_EQ(wol.source_if, "eth0");
+    EXPECT_EQ(wol.target_if, "eth1");
+    ASSERT_TRUE(wol.mac.has_value());
+    EXPECT_EQ(*wol.mac, *MacAddress::FromString("B0:37:95:C5:60:BE"));
+}
+
+TEST(ConfigTest, EnvNameDefaultsToTag) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_lan_SOURCE_IF", "eth0"},
+        {"REFLECTOR_lan_TARGET_IF", "eth1"},
+        {"REFLECTOR_lan_MDNS", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    ASSERT_EQ(config->MdnsConfigs().size(), 1u);
+    EXPECT_EQ(config->MdnsConfigs().front().name, "lan");
+}
+
+TEST(ConfigTest, EnvParamNamesAreCaseInsensitive) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_source_if", "eth0"},
+        {"REFLECTOR_1_Target_If", "eth1"},
+        {"REFLECTOR_1_WoL", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().size(), 1u);
+}
+
+TEST(ConfigTest, EnvAcceptsTrueBooleanSpellings) {
+    for (const std::string_view value : {"true", "TRUE", "True", "1"}) {
+        const auto config = Config::Load(std::nullopt, Env({
+            {"REFLECTOR_1_SOURCE_IF", "eth0"},
+            {"REFLECTOR_1_TARGET_IF", "eth1"},
+            {"REFLECTOR_1_WOL", value},
+        }));
+        ASSERT_TRUE(config.has_value()) << "value=" << value << ": " << config.error().Message();
+        EXPECT_EQ(config->WolConfigs().size(), 1u) << "value=" << value;
+    }
+}
+
+TEST(ConfigTest, EnvAcceptsFalseBooleanSpellings) {
+    for (const std::string_view value : {"false", "FALSE", "0"}) {
+        const auto config = Config::Load(std::nullopt, Env({
+            {"REFLECTOR_1_SOURCE_IF", "eth0"},
+            {"REFLECTOR_1_TARGET_IF", "eth1"},
+            {"REFLECTOR_1_WOL", value},
+            {"REFLECTOR_1_MDNS", "true"},
+        }));
+        ASSERT_TRUE(config.has_value()) << "value=" << value << ": " << config.error().Message();
+        EXPECT_TRUE(config->WolConfigs().empty()) << "value=" << value;
+        EXPECT_EQ(config->MdnsConfigs().size(), 1u) << "value=" << value;
+    }
+}
+
+TEST(ConfigTest, EnvRejectsInvalidBoolean) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "yes"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvParsesWolPortsCsv) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_1_WOL_PORTS", "7, 9, 4000"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().front().ports, (std::vector<uint16_t>{7, 9, 4000}));
+}
+
+TEST(ConfigTest, EnvRejectsInvalidWolPorts) {
+    for (const std::string_view value : {"7,x", "7,,9", "70000", "", "7,0"}) {
+        const auto config = Config::Load(std::nullopt, Env({
+            {"REFLECTOR_1_SOURCE_IF", "eth0"},
+            {"REFLECTOR_1_TARGET_IF", "eth1"},
+            {"REFLECTOR_1_WOL", "true"},
+            {"REFLECTOR_1_WOL_PORTS", value},
+        }));
+        EXPECT_FALSE(config.has_value()) << "value=" << value;
+    }
+}
+
+TEST(ConfigTest, EnvParsesAddressFamily) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_SSDP", "true"},
+        {"REFLECTOR_1_ADDRESS_FAMILY", "ipv4"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->SsdpConfigs().front().address_family, AddressFamily::IPv4);
+}
+
+TEST(ConfigTest, EnvAddressFamilyIsCaseInsensitive) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_MDNS", "true"},
+        {"REFLECTOR_1_ADDRESS_FAMILY", "DuAl"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MdnsConfigs().front().address_family, AddressFamily::Dual);
+}
+
+TEST(ConfigTest, EnvRejectsInvalidAddressFamily) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_MDNS", "true"},
+        {"REFLECTOR_1_ADDRESS_FAMILY", "ipx"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsInvalidMac) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_1_MAC", "not-a-mac"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvParsesDialFlag) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_SSDP", "true"},
+        {"REFLECTOR_1_DIAL", "1"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    ASSERT_EQ(config->SsdpConfigs().size(), 1u);
+    EXPECT_TRUE(config->SsdpConfigs().front().dial);
+}
+
+TEST(ConfigTest, EnvEnablesMultipleProtocolsFromOneTag) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_NAME", "tv"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_1_MDNS", "true"},
+        {"REFLECTOR_1_SSDP", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().size(), 1u);
+    EXPECT_EQ(config->MdnsConfigs().size(), 1u);
+    EXPECT_EQ(config->SsdpConfigs().size(), 1u);
+    EXPECT_EQ(config->WolConfigs().front().name, "tv");
+    EXPECT_EQ(config->SsdpConfigs().front().name, "tv");
+}
+
+TEST(ConfigTest, EnvParsesMultipleTags) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_2_SOURCE_IF", "eth2"},
+        {"REFLECTOR_2_TARGET_IF", "eth3"},
+        {"REFLECTOR_2_MDNS", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().size(), 1u);
+    EXPECT_EQ(config->MdnsConfigs().size(), 1u);
+}
+
+TEST(ConfigTest, EnvSetsLogLevel) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_LOG_LEVEL", "debug"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MinLogLevel(), LogLevel::Debug);
+}
+
+TEST(ConfigTest, EnvLogLevelIsCaseInsensitive) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_LOG_LEVEL", "WARNING"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MinLogLevel(), LogLevel::Warning);
+}
+
+TEST(ConfigTest, EnvRejectsInvalidLogLevel) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_LOG_LEVEL", "verbose"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvIgnoresUnrelatedVariables) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"PATH", "/usr/bin"},
+        {"REFLECTORISH", "x"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().size(), 1u);
+}
+
+TEST(ConfigTest, EnvRejectsUnknownParameter) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_1_BOGUS", "x"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsReservedLogTag) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_LOG_FORMAT", "json"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsTagWithoutParameter) {
+    EXPECT_FALSE(Config::Load(std::nullopt, Env({{"REFLECTOR_1", "x"}})).has_value());
+    EXPECT_FALSE(Config::Load(std::nullopt, Env({{"REFLECTOR_1_", "x"}})).has_value());
+}
+
+TEST(ConfigTest, EnvRejectsEmptyTag) {
+    // REFLECTOR__SOURCE_IF: nothing between the prefix and the first underscore -> empty tag.
+    EXPECT_FALSE(Config::Load(std::nullopt, Env({{"REFLECTOR__SOURCE_IF", "eth0"}})).has_value());
+}
+
+TEST(ConfigTest, EnvRejectsNonAlphanumericTag) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_a.b_SOURCE_IF", "eth0"},
+        {"REFLECTOR_a.b_TARGET_IF", "eth1"},
+        {"REFLECTOR_a.b_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsDuplicateNameAcrossTags) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_1_NAME", "tv"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+        {"REFLECTOR_2_NAME", "tv"},
+        {"REFLECTOR_2_SOURCE_IF", "eth2"},
+        {"REFLECTOR_2_TARGET_IF", "eth3"},
+        {"REFLECTOR_2_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsEmptyConfiguration) {
+    EXPECT_FALSE(Config::Load(std::nullopt, std::span<const EnvVar>{}).has_value());
+    EXPECT_FALSE(Config::Load(std::nullopt, Env({{"PATH", "/usr/bin"}})).has_value());
+}
+
+// --- merging a TOML file with environment variables ---
+
+TEST(ConfigTest, MergeCombinesFileAndEnvEntries) {
+    const auto config = Config::Load(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({
+        {"REFLECTOR_radio_SOURCE_IF", "eth2"},
+        {"REFLECTOR_radio_TARGET_IF", "eth3"},
+        {"REFLECTOR_radio_MDNS", "true"},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    ASSERT_EQ(config->WolConfigs().size(), 1u);
+    ASSERT_EQ(config->MdnsConfigs().size(), 1u);
+    EXPECT_EQ(config->WolConfigs().front().name, "tv");
+    EXPECT_EQ(config->MdnsConfigs().front().name, "radio");
+}
+
+TEST(ConfigTest, MergeDetectsCrossSourceDuplicate) {
+    const auto config = Config::Load(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({
+        {"REFLECTOR_other_SOURCE_IF", "eth0"},
+        {"REFLECTOR_other_TARGET_IF", "eth1"},
+        {"REFLECTOR_other_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, MergeDetectsDuplicateNameAcrossSources) {
+    const auto config = Config::Load(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({
+        {"REFLECTOR_x_NAME", "tv"},
+        {"REFLECTOR_x_SOURCE_IF", "eth2"},
+        {"REFLECTOR_x_TARGET_IF", "eth3"},
+        {"REFLECTOR_x_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvLogLevelOverridesFile) {
+    const auto config = Config::Load(R"(
+log_level = "error"
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({{"REFLECTOR_LOG_LEVEL", "debug"}}));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MinLogLevel(), LogLevel::Debug);
+}
+
+TEST(ConfigTest, FileLogLevelKeptWhenEnvUnset) {
+    const auto config = Config::Load(R"(
+log_level = "warning"
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", std::span<const EnvVar>{});
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MinLogLevel(), LogLevel::Warning);
+}
+
+TEST(ConfigTest, EnvLogLevelSetsWhenFileOmitsIt) {
+    // File contributes an entry but no log_level; the env supplies it (sole setter, not an override).
+    const auto config = Config::Load(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({{"REFLECTOR_LOG_LEVEL", "debug"}}));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->MinLogLevel(), LogLevel::Debug);
 }
 
 }  // namespace reflector

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "mocks/fake_interface.h"
-#include "reflector/config.h"
+#include "reflector/config/config.h"
 #include "reflector/interface.h"
 #include "reflector/ip_address.h"
 #include "reflector/logger.h"


### PR DESCRIPTION
## Summary

Adds configuration via `REFLECTOR_<TAG>_<PARAM>` environment variables, mergeable with the existing TOML file — convenient for containers and RouterOS where mounting a file is awkward. Version bumped to 0.5.0.

> [!WARNING]
> **Breaking change:** running with no argument no longer defaults to `./config.toml`; with no argument the configuration now comes entirely from the environment. The published Docker image drops its default `CMD` to match.

## How env config works

- **Grammar `REFLECTOR_<TAG>_<PARAM>`:** `<TAG>` is any alphanumeric string (`1`, `2`, `TV`, …) tying one entry's parameters together; it doubles as the entry's name unless a `NAME` param overrides it. `<PARAM>` is `NAME` or any entry field (`SOURCE_IF`, `TARGET_IF`, `MAC`, `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive. Parsed by splitting on the first underscore after the tag.
- **Global:** `REFLECTOR_LOG_LEVEL` (so `LOG` is a reserved tag).
- **Coercion:** booleans accept `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`).
- **Merge:** file and env entries combine into one configuration sharing the same duplicate detection; `REFLECTOR_LOG_LEVEL` overrides the file's `log_level`; entry names must be unique across both sources.

## Design

The parser was first refactored to split **field extraction** (per source) from **field interpretation** (shared): `ReadEntry` consumes a `ConfigSource` interface, with `TomlSource` and `EnvSource` as the two backends, so validation, duplicate detection, and protocol expansion are identical regardless of source. The env feature then plugged into that seam.

## Commits

1. `build`: bump version to 0.5.0
2. `refactor`: parse config entries through a `ConfigSource` abstraction
3. `feat`: configure the daemon from environment variables
4. `test`: close config coverage gaps + fix a spuriously-passing `dial` test
5. `refactor`: split config into a `config/` subdirectory

## Testing

Full gate green: native unit (ASan/UBSan), Docker debug + release (g++-14 `-Werror`), e2e, Valgrind (unit + e2e), and armv7/armv5 cross-builds — shipping image plus the ubuntu-24.04 CI `-Werror` reproduction under QEMU. A behavioral coverage audit drove ~30 new config tests and surfaced a pre-existing `dial` test that passed for the wrong reason (now fixed).

## Docs

README documents the env grammar, merge behavior, and updated Docker/RouterOS usage; the Dockerfile drops its default `CMD`.
