### PR TITLE
FreeBSD support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,13 @@ jobs:
       - name: Build
         run: cmake --build build
 
+      # macOS (like FreeBSD) only binds explicitly-assigned loopback addresses, so the two DIAL tests
+      # that bind 127.0.0.2 self-skip. Add the alias so they run here too (Linux makes all of 127/8
+      # bindable, so it needs nothing). Best-effort — the tests just skip again if it doesn't take.
+      - name: Add 127.0.0.2 loopback alias for the DIAL tests (macOS)
+        if: matrix.platform == 'macos'
+        run: sudo ifconfig lo0 alias 127.0.0.2 || true
+
       # Native lanes run under sudo so the RequiresRoot tests (loopback capture, veth/feth pairs needing
       # CAP_NET_RAW/CAP_NET_ADMIN or bpf + root) run instead of skipping; each fixture probes its operation
       # and GTEST_SKIPs where unavailable. The cross (armv7) lane runs without sudo: under user-mode QEMU
@@ -125,6 +132,52 @@ jobs:
           else
             sudo ctest --test-dir build --output-on-failure
           fi
+
+  freebsd:
+    name: Unit (freebsd-amd64 ${{ matrix.build_type }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      # FreeBSD shares its BSD platform path (kqueue, BPF, route sockets, getifaddrs) with macOS but needs
+      # a real FreeBSD kernel to build and test — Docker can't provide one. vmactions boots a FreeBSD VM via
+      # QEMU inside the Linux runner (same spirit as the armv7/armv5-under-QEMU lanes above) and runs the
+      # script inside it. The VM runs as root, so the RequiresRoot tests (BPF capture, epair pairs) run
+      # instead of skipping; each fixture self-skips where its operation isn't available.
+      - name: Build and test in a FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: '14.2'  # 14.x base ships clang/libc++ >= 18 (std::println/format/expected); OPNsense 25.x tracks 14.3
+          usesh: true
+          prepare: |
+            # Upgrade the image's pre-installed packages before installing ours: the base VM ships an
+            # older pcre2 than the git in the current pkg catalogue links against, so a freshly
+            # pkg-installed git fails to load ("ld-elf.so.1: ... PCRE2_10.47 ... not defined"). That
+            # makes cmake's find_package(Git) read an empty version and abort FetchContent. Upgrading
+            # first brings the shared libs in line with what we install.
+            pkg upgrade -y
+            pkg install -y cmake ninja git
+          run: |
+            cmake --version
+            c++ --version
+            # Release is the static config we ship (REFLECTOR_STATIC); Debug stays dynamic so it can
+            # carry ASan/UBSan (the two are mutually exclusive). Same split as the Linux lanes.
+            if [ "${{ matrix.build_type }}" = Release ]; then static=ON; sanitize=OFF; else static=OFF; sanitize=ON; fi
+            cmake -S . -B build -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -D REFLECTOR_STATIC=$static -D REFLECTOR_SANITIZE=$sanitize
+            cmake --build build
+            # FreeBSD (like macOS) only binds explicitly-assigned loopback addresses, so add 127.0.0.2
+            # for the two DIAL tests; best-effort — they skip again if it doesn't take.
+            ifconfig lo0 alias 127.0.0.2/32 || true
+            ctest --test-dir build --output-on-failure
 
   docker-e2e:
     name: Docker e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,55 @@ jobs:
           path: dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}
           if-no-files-found: error
 
+  # FreeBSD has no native runner and Docker can't run a FreeBSD kernel, so build in a VM (vmactions).
+  # amd64 is KVM-accelerated; arm64 has no KVM on any GitHub-hosted runner, so it builds emulated on the
+  # (measurably faster) amd64 host. Static (REFLECTOR_STATIC) — verified to run across FreeBSD 13/14/15 —
+  # so one binary per arch, no per-major split.
+  binaries-freebsd:
+    name: Binary (freebsd-${{ matrix.arch }})
+    needs: verify-ci
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            vm_arch: x86_64
+          - arch: arm64
+            vm_arch: aarch64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build the static release binary in a FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: '14.2'
+          arch: ${{ matrix.vm_arch }}
+          usesh: true
+          prepare: |
+            pkg upgrade -y
+            pkg install -y cmake ninja git
+          run: |
+            cmake -S . -B build -G Ninja \
+              -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTING=OFF -D REFLECTOR_STATIC=ON
+            cmake --build build --target reflector_app
+            file build/reflector
+            file build/reflector | grep -q 'statically linked' \
+              || { echo "::error::reflector is not statically linked"; exit 1; }
+            mkdir -p dist
+            cp build/reflector "dist/reflector-${{ github.ref_name }}-freebsd-${{ matrix.arch }}"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: reflector-freebsd-${{ matrix.arch }}
+          path: dist/reflector-${{ github.ref_name }}-freebsd-${{ matrix.arch }}
+          if-no-files-found: error
+
   # Each arch builds on its own native runner (no emulation), pushes by digest, and the manifest job
   # stitches the digests into one multi-arch tag.
   image:
@@ -264,7 +313,7 @@ jobs:
 
   release:
     name: GitHub release
-    needs: [binaries, manifest]
+    needs: [binaries, binaries-freebsd, manifest]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.28)
-project(reflector VERSION 0.5.1 LANGUAGES CXX)
+project(reflector VERSION 0.6.0 LANGUAGES CXX)
 include(CTest)
 
-if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}. Only Linux and macOS are supported.")
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+        OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
+    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}. Only Linux, macOS, and FreeBSD are supported.")
 endif()
 
 # Standard library bits used here (std::println, std::expected, std::format) need a recent toolchain.
@@ -16,6 +17,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSIO
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# This project uses #include, not C++20 modules, so skip module dependency scanning. It's wasted work
+# regardless, and the Clang scan path needs clang-scan-deps, which FreeBSD's base clang doesn't ship
+# (only the llvm package does) — leaving it on makes the FreeBSD build fail with a NOTFOUND scanner.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(_reflector_sanitize_default ON)
@@ -31,16 +37,16 @@ option(REFLECTOR_ENABLE_DOCKER_TESTS "Enable Docker-backed build tests" OFF)
 option(REFLECTOR_ENABLE_VALGRIND_UNIT_TESTS "Enable the Docker-backed unit suite under Valgrind memcheck" OFF)
 option(REFLECTOR_ENABLE_VALGRIND_E2E_TESTS "Enable the Docker-backed e2e suite with the reflector under Valgrind memcheck" OFF)
 option(REFLECTOR_ENABLE_CCACHE "Use ccache as the compiler launcher when available" ON)
-option(REFLECTOR_STATIC "Statically link the reflector binaries (Linux only)" OFF)
+option(REFLECTOR_STATIC "Statically link the reflector binaries (Linux and FreeBSD)" OFF)
 
 # REFLECTOR_STATIC statically links every project target — the production binary (for a FROM-scratch
 # image and portable release binaries) and the test binary (so the suite exercises what ships). Linux
-# only (macOS has no static libSystem); incompatible with the ASan/UBSan runtime, so the sanitized
-# debug and the Valgrind runs stay dynamic. reflector resolves no hostnames (no NSS), so glibc -static
-# is self-contained — no "needs the shared libs at runtime" trap.
+# and FreeBSD only (macOS has no static libSystem); incompatible with the ASan/UBSan runtime, so the
+# sanitized debug and the Valgrind runs stay dynamic. reflector resolves no hostnames (no NSS), so a
+# -static binary is self-contained on both — no "needs the shared libs at runtime" trap.
 if(REFLECTOR_STATIC)
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        message(FATAL_ERROR "REFLECTOR_STATIC is Linux-only; macOS has no static libSystem.")
+    if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
+        message(FATAL_ERROR "REFLECTOR_STATIC supports Linux and FreeBSD only; macOS has no static libSystem.")
     endif()
     if(REFLECTOR_SANITIZE)
         message(FATAL_ERROR "REFLECTOR_STATIC is incompatible with REFLECTOR_SANITIZE (ASan/UBSan need the dynamic runtime).")

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ keeps running. The per-protocol re-emit details are described under [Configurati
 
 ## Platform support
 
-Linux and macOS. The CI workflow runs the unit suite on Ubuntu 24.04 x64, Ubuntu 24.04 arm64, and macOS 15, plus cross-compiled 32-bit ARM builds (`linux/arm/v7` and `linux/arm/v5`) whose unit suites run under QEMU; it also runs Docker build and e2e jobs on Ubuntu 24.04.
+Linux, macOS, and FreeBSD. The CI workflow runs the unit suite on Ubuntu 24.04 x64, Ubuntu 24.04 arm64, macOS 15, and FreeBSD 14 (amd64, in a QEMU VM), plus cross-compiled 32-bit ARM builds (`linux/arm/v7` and `linux/arm/v5`) whose unit suites run under QEMU; it also runs Docker build and e2e jobs on Ubuntu 24.04.
 
 The published multi-arch Docker image targets `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`. The 32-bit ARM variants let it run on MikroTik routers through the RouterOS *Container* feature: `arm/v7` for older ARMv7 devices (e.g. RB3011, RB4011, hAP ac2/ac3, CRS3xx), and `arm/v5` for the newer low-end ARMv5 boxes built on the EN7562CT SoC (hEX refresh, hEX S refresh, hAP ax S).
+
+FreeBSD isn't a Docker target (Docker shares the host's Linux kernel), so each release additionally ships a standalone **static** FreeBSD binary for `amd64` and `arm64`. Built on FreeBSD 14, they are statically linked and run across FreeBSD 13, 14, and 15 (verified in CI).
 
 ## Build
 
@@ -111,6 +113,14 @@ open "/Applications/Wireshark.app/Contents/Resources/Extras/Install ChmodBPF.pkg
 ```
 
 Log out and back in after installing for the group membership to take effect.
+
+#### FreeBSD
+
+Capture uses BPF (`/dev/bpf*`), like macOS; egress re-emits frames through the BPF device, and the DIAL
+proxy's TCP connect pins its interface by binding the source address (FreeBSD has no `IP_BOUND_IF`), so
+no port privileges are needed. BPF devices are root-only by default, so out of the box the reflector
+must run as root. To run unprivileged, grant a group read/write on `/dev/bpf*` with a devfs ruleset
+(`/etc/devfs.rules` + `devfs_system_ruleset` in `/etc/rc.conf`) and add the user to that group.
 
 ### Run in Docker
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "reflector/application.h"
 #include "reflector/config/config.h"
 #include "reflector/logger.h"
+#include "reflector/util/narrow_cast.h"
 
 #include <cstdio>
 #include <csignal>
@@ -52,7 +53,9 @@ volatile std::sig_atomic_t g_wakeup_fd = -1;
 
 void SignalHandler(int) {
     g_stop_requested = 1;
-    const int wakeup_fd = g_wakeup_fd;
+    // std::sig_atomic_t is wider than int on some platforms (long on FreeBSD), so narrow explicitly.
+    // narrow_cast is a plain static_cast — async-signal-safe (no runtime check) for use in the handler.
+    const int wakeup_fd = reflector::narrow_cast<int>(g_wakeup_fd);
     if (wakeup_fd >= 0) {
         // write() is async-signal-safe; best-effort, so a full/not-ready pipe (the result we ignore) is
         // fine -- a byte already pending is enough to wake the loop, which then re-checks g_stop_requested.

--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -2,6 +2,7 @@
 
 #include "error.h"
 #include "logger.h"
+#include "platform.h"
 #include "util/fd_util.h"
 
 #include <algorithm>
@@ -14,14 +15,10 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#if !defined(__APPLE__) && !defined(__linux__)
-#error "AddressMonitor only supports macOS and Linux"
-#endif
-
 #if defined(__linux__)
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#elif defined(__APPLE__)
+#else
 #include <net/if.h>
 #include <net/route.h>
 #endif
@@ -94,7 +91,7 @@ bool DefaultAddressMonitor::Open() noexcept {
         GetLogger().Error("Cannot subscribe to netlink address groups: {}", Error::FromErrno());
         return false;
     }
-#elif defined(__APPLE__)
+#else
     fd_.Reset(socket(PF_ROUTE, SOCK_RAW, 0));
     if (!fd_) {
         GetLogger().Error("Cannot open route socket: {}", Error::FromErrno());
@@ -206,7 +203,7 @@ void DefaultAddressMonitor::CollectChangedInterfaces(std::span<const std::byte> 
 
 #pragma GCC diagnostic pop
 
-#elif defined(__APPLE__)
+#else
 
 void DefaultAddressMonitor::CollectChangedInterfaces(std::span<const std::byte> messages,
         std::vector<unsigned>& changed) const noexcept {

--- a/src/reflector/default_packet_dispatcher.cpp
+++ b/src/reflector/default_packet_dispatcher.cpp
@@ -1,6 +1,7 @@
 #include "default_packet_dispatcher.h"
 
 #include "logger.h"
+#include "platform.h"
 #include "util/delegate.h"
 
 #include <algorithm>
@@ -95,14 +96,14 @@ void DefaultPacketDispatcher::DrainReadableFd(LinkSocket& socket) noexcept {
     // for the rest of the drain, then loses its capture source in the sweep.
     dispatching_ = true;
 
-#if defined(__APPLE__)
-    for (size_t packet_count = 0; packet_count < MAX_PACKETS_PER_READ_EVENT || socket.HasBufferedData(); ++packet_count) {
-#elif defined(__linux__)
+#if defined(__linux__)
     for (size_t packet_count = 0; packet_count < MAX_PACKETS_PER_READ_EVENT; ++packet_count) {
+#else
+    for (size_t packet_count = 0; packet_count < MAX_PACKETS_PER_READ_EVENT || socket.HasBufferedData(); ++packet_count) {
 #endif
         const auto packet = socket.Receive();
         if (!packet) {
-#if defined(__APPLE__)
+#if !defined(__linux__)
             if (socket.HasBufferedData()) {
                 // Drain all userland-buffered frames. kqueue/epoll only fire on kernel-side
                 // activity, so if we leave frames buffered they'll stall. Only macOS BPF

--- a/src/reflector/event_loop_dispatcher.cpp
+++ b/src/reflector/event_loop_dispatcher.cpp
@@ -2,6 +2,7 @@
 
 #include "error.h"
 #include "logger.h"
+#include "platform.h"
 
 #include <algorithm>
 #include <cerrno>
@@ -10,21 +11,17 @@
 #include <vector>
 #include <unistd.h>
 
-#if !defined(__APPLE__) && !defined(__linux__)
-#error "EventLoopDispatcher only supports macOS and Linux"
-#endif
-
-#if defined(__APPLE__)
-#include <sys/event.h>
-#elif defined(__linux__)
+#if defined(__linux__)
 #include <sys/epoll.h>
+#else
+#include <sys/event.h>
 #endif
 
 namespace {
 
 using namespace reflector;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 timespec ToTimespec(std::chrono::milliseconds timeout) noexcept {
     return timespec{
         .tv_sec = static_cast<time_t>(timeout.count() / 1000),
@@ -43,10 +40,10 @@ Logger& GetLogger() noexcept {
 namespace reflector {
 
 EventLoopDispatcher::EventLoopDispatcher() {
-#if defined(__APPLE__)
-    event_fd_.Reset(kqueue());
-#elif defined(__linux__)
+#if defined(__linux__)
     event_fd_.Reset(epoll_create1(0));
+#else
+    event_fd_.Reset(kqueue());
 #endif
 
     if (!event_fd_) {
@@ -153,7 +150,23 @@ bool EventLoopDispatcher::PollOnce(std::chrono::milliseconds timeout) {
         return false;
     }
 
-#if defined(__APPLE__)
+#if defined(__linux__)
+    epoll_event event{};
+    const auto event_count = epoll_wait(event_fd_.Get(), &event, 1, static_cast<int>(timeout.count()));
+    if (event_count < 0) {
+        if (errno == EINTR) {
+            // Expected when a signal interrupts polling; callers decide whether to retry or shut down.
+            return false;
+        }
+        GetLogger().Error("Cannot poll dispatcher read events: {}", Error::FromErrno());
+        return false;
+    }
+    if (event_count == 0) {
+        return false;
+    }
+    const auto fd = event.data.fd;
+    const auto events = event.events;
+#else
     auto timeout_spec = ToTimespec(timeout);
     struct kevent event{};
     const auto event_count = kevent(event_fd_.Get(), nullptr, 0, &event, 1, &timeout_spec);
@@ -173,22 +186,6 @@ bool EventLoopDispatcher::PollOnce(std::chrono::milliseconds timeout) {
         GetLogger().Error("Dispatcher read event failed for fd {}: {}", fd, event.data);
         return false;
     }
-#elif defined(__linux__)
-    epoll_event event{};
-    const auto event_count = epoll_wait(event_fd_.Get(), &event, 1, static_cast<int>(timeout.count()));
-    if (event_count < 0) {
-        if (errno == EINTR) {
-            // Expected when a signal interrupts polling; callers decide whether to retry or shut down.
-            return false;
-        }
-        GetLogger().Error("Cannot poll dispatcher read events: {}", Error::FromErrno());
-        return false;
-    }
-    if (event_count == 0) {
-        return false;
-    }
-    const auto fd = event.data.fd;
-    const auto events = event.events;
 #endif
 
     const auto it = callbacks_.find(fd);
@@ -197,10 +194,7 @@ bool EventLoopDispatcher::PollOnce(std::chrono::milliseconds timeout) {
         return false;
     }
 
-#if defined(__APPLE__)
-    const bool readable = event.filter == EVFILT_READ;
-    const bool writable = event.filter == EVFILT_WRITE;
-#elif defined(__linux__)
+#if defined(__linux__)
     // EPOLLERR/EPOLLHUP can arrive without EPOLLIN/EPOLLOUT (a failed connect surfaces as EPOLLERR,
     // often with no EPOLLOUT; a peer hangup as EPOLLHUP). Fold the error into READABLE only: read is
     // always armed, so the read handler is woken to recv() the EOF/error and tear down — the uniform
@@ -209,6 +203,9 @@ bool EventLoopDispatcher::PollOnce(std::chrono::milliseconds timeout) {
     const bool err = (events & (EPOLLERR | EPOLLHUP)) != 0;
     const bool readable = (events & EPOLLIN) != 0 || err;
     const bool writable = (events & EPOLLOUT) != 0;
+#else
+    const bool readable = event.filter == EVFILT_READ;
+    const bool writable = event.filter == EVFILT_WRITE;
 #endif
 
     // Read is always armed and always has a valid handler (Register requires one), so readability
@@ -335,7 +332,19 @@ bool EventLoopDispatcher::SetEvents(int fd, bool enable_write) noexcept {
         return false;
     }
 
-#if defined(__APPLE__)
+#if defined(__linux__)
+    // epoll has no per-direction toggle — rewrite the whole mask (read always on). MOD an already-
+    // watched fd; on its first call (from Register) it is not in the set yet, so MOD returns ENOENT and
+    // we ADD.
+    epoll_event event{};
+    event.events = EPOLLIN | (enable_write ? EPOLLOUT : 0u);
+    event.data.fd = fd;
+    if (epoll_ctl(event_fd_.Get(), EPOLL_CTL_MOD, fd, &event) != 0
+        && (errno != ENOENT || epoll_ctl(event_fd_.Get(), EPOLL_CTL_ADD, fd, &event) != 0)) {
+        GetLogger().Error("Cannot set events for fd {}: {}", fd, Error::FromErrno());
+        return false;
+    }
+#else
     // Read is always armed; re-EV_ADD'ing an already-present filter is idempotent. The write filter is
     // EV_ADD'd only when arming — so EVFILT_WRITE is never EV_ADD'd on a BPF capture device (which
     // rejects it with EINVAL); disarming uses bare EV_DISABLE, tolerating ENOENT when it was never added.
@@ -351,18 +360,6 @@ bool EventLoopDispatcher::SetEvents(int fd, bool enable_write) noexcept {
         GetLogger().Error("Cannot set write interest for fd {}: {}", fd, Error::FromErrno());
         return false;
     }
-#elif defined(__linux__)
-    // epoll has no per-direction toggle — rewrite the whole mask (read always on). MOD an already-
-    // watched fd; on its first call (from Register) it is not in the set yet, so MOD returns ENOENT and
-    // we ADD.
-    epoll_event event{};
-    event.events = EPOLLIN | (enable_write ? EPOLLOUT : 0u);
-    event.data.fd = fd;
-    if (epoll_ctl(event_fd_.Get(), EPOLL_CTL_MOD, fd, &event) != 0
-        && (errno != ENOENT || epoll_ctl(event_fd_.Get(), EPOLL_CTL_ADD, fd, &event) != 0)) {
-        GetLogger().Error("Cannot set events for fd {}: {}", fd, Error::FromErrno());
-        return false;
-    }
 #endif
 
     GetLogger().Debug("Set events for fd {}: write {}", fd, enable_write);
@@ -375,7 +372,14 @@ bool EventLoopDispatcher::RemoveEvents(int fd) noexcept {
         return false;
     }
 
-#if defined(__APPLE__)
+#if defined(__linux__)
+    // ENOENT is benign: the kernel auto-removes a closed fd, so a DEL issued after the owner already
+    // closed it hits ENOENT (matching the kqueue branch below). Any other failure is a real error.
+    if (epoll_ctl(event_fd_.Get(), EPOLL_CTL_DEL, fd, nullptr) != 0 && errno != ENOENT) {
+        GetLogger().Error("Cannot remove events for fd {}: {}", fd, Error::FromErrno());
+        return false;
+    }
+#else
     // Delete both filters. A filter can be absent — the write filter if write was never armed, or
     // either one if the fd was already closed (kqueue auto-removes a closed fd's filters) — so an
     // EV_DELETE returning ENOENT is benign; any other failure is a real error.
@@ -389,13 +393,6 @@ bool EventLoopDispatcher::RemoveEvents(int fd) noexcept {
         }
     }
     if (!ok) {
-        return false;
-    }
-#elif defined(__linux__)
-    // ENOENT is benign: the kernel auto-removes a closed fd, so a DEL issued after the owner already
-    // closed it hits ENOENT (matching the macOS branch above). Any other failure is a real error.
-    if (epoll_ctl(event_fd_.Get(), EPOLL_CTL_DEL, fd, nullptr) != 0 && errno != ENOENT) {
-        GetLogger().Error("Cannot remove events for fd {}: {}", fd, Error::FromErrno());
         return false;
     }
 #endif

--- a/src/reflector/frame_builder.cpp
+++ b/src/reflector/frame_builder.cpp
@@ -2,6 +2,7 @@
 
 #include "checksum.h"
 #include "logger.h"
+#include "platform.h"
 #include "protocol_constants.h"
 #include "util/byte_order.h"
 
@@ -138,7 +139,7 @@ size_t BuildUdpFrame(
     return frame_size;
 }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 size_t BuildLoopbackUdpFrame(
     const IpEndpoint& src,
     const IpEndpoint& dst,

--- a/src/reflector/frame_builder.h
+++ b/src/reflector/frame_builder.h
@@ -3,6 +3,7 @@
 #include "ip_address.h"
 #include "ip_endpoint.h"
 #include "mac_address.h"
+#include "platform.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -32,7 +33,7 @@ namespace reflector {
     uint8_t ttl,
     std::span<std::byte> out) noexcept;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 // Like BuildUdpFrame but with BSD DLT_NULL framing (a 4-byte host-order address family in place
 // of the Ethernet header, and no L2 MACs), as used on the macOS loopback interface (lo0). Linux
 // frames loopback as Ethernet, so this exists only on macOS.

--- a/src/reflector/interface.cpp
+++ b/src/reflector/interface.cpp
@@ -1,9 +1,9 @@
 #include "interface.h"
 
 #include "error.h"
+#include "platform.h"
 
 #include <format>
-
 #include <net/if.h>
 
 namespace reflector {
@@ -45,7 +45,7 @@ bool Interface::CanSend(IpAddress::Family family) const noexcept {
 void Interface::Refresh() noexcept {
 #if defined(__linux__)
     addresses_ = ResolveInterfaceAddresses(index_);
-#elif defined(__APPLE__)
+#else
     addresses_ = ResolveInterfaceAddresses(name_);
 #endif
     logger_.Debug("Resolved addresses (index {}): MAC {}, IPv4 {}, IPv6 {}", index_,

--- a/src/reflector/interface_address.cpp
+++ b/src/reflector/interface_address.cpp
@@ -2,6 +2,7 @@
 
 #include "error.h"
 #include "logger.h"
+#include "platform.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -21,7 +22,7 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <cerrno>
-#elif defined(__APPLE__)
+#else
 #include <ifaddrs.h>
 #include <net/if_dl.h>
 #include <netinet/in.h>
@@ -256,7 +257,7 @@ void ResolveViaNetlink(unsigned index, InterfaceAddresses& result) noexcept {
 
 #pragma GCC diagnostic pop
 
-#elif defined(__APPLE__)
+#else
 
 // The interface's link-layer MAC from a sockaddr_dl, or a default (all-zero) MacAddress if it
 // has none. Reads straight out of the kernel-provided sockaddr rather than copying the whole
@@ -371,7 +372,7 @@ InterfaceAddresses ResolveInterfaceAddresses(unsigned interface_index) noexcept 
     return result;
 }
 
-#elif defined(__APPLE__)
+#else
 
 InterfaceAddresses ResolveInterfaceAddresses(std::string_view interface) noexcept {
     InterfaceAddresses result;

--- a/src/reflector/interface_address.h
+++ b/src/reflector/interface_address.h
@@ -2,6 +2,7 @@
 
 #include "ip_address.h"
 #include "mac_address.h"
+#include "platform.h"
 
 #include <optional>
 #include <span>
@@ -37,7 +38,7 @@ void SelectSourceAddresses(std::span<const IpAddress> candidates, InterfaceAddre
 // the kernel interface index on Linux (netlink), the interface name on macOS (getifaddrs).
 #if defined(__linux__)
 [[nodiscard]] InterfaceAddresses ResolveInterfaceAddresses(unsigned interface_index) noexcept;
-#elif defined(__APPLE__)
+#else
 [[nodiscard]] InterfaceAddresses ResolveInterfaceAddresses(std::string_view interface) noexcept;
 #endif
 

--- a/src/reflector/ip_address.cpp
+++ b/src/reflector/ip_address.cpp
@@ -2,6 +2,7 @@
 
 #include "reflector/error.h"
 #include "reflector/logger.h"
+#include "reflector/platform.h"
 #include "reflector/util/narrow_cast.h"
 
 #include <arpa/inet.h>
@@ -174,7 +175,7 @@ socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsign
         v4->sin_family = AF_INET;
         v4->sin_port = htons(port);
         std::memcpy(&v4->sin_addr, bytes_.data(), sizeof(v4->sin_addr));
-#if defined(__APPLE__)
+#if !defined(__linux__)
         // BSD carries the length in the sockaddr. bind/sendto ignore it (they take an explicit
         // addrlen), but APIs that parse an embedded sockaddr — e.g. MCAST_JOIN_GROUP's gr_group —
         // require it, so fill it here rather than at each such call site.
@@ -188,7 +189,7 @@ socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsign
         v6->sin6_port = htons(port);
         v6->sin6_scope_id = scope_id;
         std::memcpy(&v6->sin6_addr, bytes_.data(), sizeof(v6->sin6_addr));
-#if defined(__APPLE__)
+#if !defined(__linux__)
         v6->sin6_len = sizeof(sockaddr_in6);
 #endif
         return sizeof(sockaddr_in6);

--- a/src/reflector/link_socket.h
+++ b/src/reflector/link_socket.h
@@ -4,6 +4,7 @@
 #include "ip_endpoint.h"
 #include "mac_address.h"
 #include "packet.h"
+#include "platform.h"
 #include "util/registration.h"
 
 #include <cstddef>
@@ -37,7 +38,7 @@ public:
     // until the next Receive() on the same socket.
     [[nodiscard]] virtual std::optional<Packet> Receive() noexcept = 0;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // macOS BPF batches several frames into one read(); this lets the dispatcher keep draining the
     // userland buffer past the per-event cap while frames remain. Not on Linux, where AF_PACKET
     // delivers one frame per recv with no userland buffering.

--- a/src/reflector/platform.h
+++ b/src/reflector/platform.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// IWYU pragma: always_keep
+//
+// Single supported-platform contract for the whole project. Linux is the outlier (netlink,
+// AF_PACKET, epoll); macOS and FreeBSD share the BSD path (kqueue, BPF, route sockets,
+// getifaddrs). Platform-specific code branches on __linux__ and routes everything else through
+// #else, so an unsupported OS would otherwise silently compile the BSD path and fail with
+// confusing downstream errors. Every file that makes a platform assumption includes this header
+// so the failure is one clear message instead.
+#if !defined(__linux__) && !defined(__APPLE__) && !defined(__FreeBSD__)
+#error "reflector only supports Linux, macOS, and FreeBSD"
+#endif

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -4,6 +4,7 @@
 #include "frame_builder.h"
 #include "ip_address.h"
 #include "mac_address.h"
+#include "platform.h"
 #include "protocol_constants.h"
 #include "util/byte_order.h"
 #include "util/fd_util.h"
@@ -28,10 +29,6 @@
 #include <unistd.h>
 #include <utility>
 
-#if !defined(__APPLE__) && !defined(__linux__)
-#error "RawSocket only supports macOS and Linux"
-#endif
-
 #if defined(__linux__)
 #include <linux/filter.h>
 #include <linux/if_ether.h>
@@ -43,7 +40,7 @@
 #ifndef PACKET_IGNORE_OUTGOING
 #define PACKET_IGNORE_OUTGOING 23
 #endif
-#elif defined(__APPLE__)
+#else
 #include <net/bpf.h>
 #include <net/ethernet.h>
 #include <sys/uio.h>
@@ -109,7 +106,7 @@ constexpr std::array<BpfInsn, 3> DROP_OUTGOING_PROLOGUE{{
 }};
 #endif
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 // DLT_NULL framing: 4-byte address family in host byte order (BSD loopback driver
 // convention), then the IP packet. The data layout is host-endian, but the classic
 // BPF VM's BPF_LD|BPF_W|BPF_ABS always interprets the loaded 4 bytes as big-endian
@@ -158,7 +155,7 @@ constexpr size_t DEFAULT_RECEIVE_BUFFER_SIZE = 4 * 1024;
 // caller ever exceeds it.
 constexpr size_t SEND_BUFFER_SIZE = 4 * 1024;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 // DLT_NULL framing: 4 bytes of address family in host byte order, then the IP packet.
 constexpr size_t LOOPBACK_FAMILY_SIZE = 4;
 #endif
@@ -229,7 +226,7 @@ RawSocket::RawSocket(const Interface& interface)
 
     logger_.Debug("Opened AF_PACKET socket fd {} on interface", fd_.Get());
 
-#elif defined(__APPLE__)
+#else
     for (int n = 0; n < 256 && !fd_; ++n) {
         const auto path = std::format("/dev/bpf{}", n);
         fd_.Reset(open(path.c_str(), O_RDWR));
@@ -382,7 +379,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
 #if defined(__linux__)
     const size_t length = BuildUdpFrame(dst_mac, interface_.Mac(), IpEndpoint{*source, src_port}, dst,
         payload, ttl, frame);
-#elif defined(__APPLE__)
+#else
     const size_t length = link_type_ == LinkType::Loopback
         ? BuildLoopbackUdpFrame(IpEndpoint{*source, src_port}, dst, payload, ttl, frame)
         : BuildUdpFrame(dst_mac, interface_.Mac(), IpEndpoint{*source, src_port}, dst, payload, ttl, frame);
@@ -401,7 +398,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
     addr.sll_ifindex = static_cast<int>(interface_.Index());
     const auto sent = sendto(fd_.Get(), frame.data(), length, 0,
         reinterpret_cast<const sockaddr*>(&addr), sizeof(addr));
-#elif defined(__APPLE__)
+#else
     const auto sent = write(fd_.Get(), frame.data(), length);
 #endif
     if (sent < 0 || static_cast<size_t>(sent) != length) {
@@ -496,7 +493,7 @@ bool RawSocket::Unregister(const IpAddress& group) noexcept {
     return true;
 }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 bool RawSocket::HasBufferedData() const noexcept {
     return receive_buffer_offset_ < receive_buffer_filled_;
 }
@@ -518,7 +515,7 @@ void RawSocket::Close() noexcept {
     join_fds_.V6().Reset();
     group_memberships_.V4().clear();
     group_memberships_.V6().clear();
-#if defined(__APPLE__)
+#if !defined(__linux__)
     ClearBuffer();
 #endif
 }
@@ -549,7 +546,7 @@ std::optional<Packet> RawSocket::Receive() noexcept {
     }
     return ParseFrame({receive_buffer_.data(), static_cast<size_t>(bytes)});
 
-#elif defined(__APPLE__)
+#else
     if (receive_buffer_offset_ >= receive_buffer_filled_) {
         ssize_t bytes;
         do {
@@ -606,7 +603,7 @@ std::optional<Packet> RawSocket::ParseFrame(std::span<const std::byte> frame) no
     MacAddress dest_mac{};
     std::span<const std::byte> l3;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     if (link_type_ == LinkType::Loopback) {
         // DLT_NULL: 4-byte address family in host byte order, then the IP packet. No L2,
         // so MACs stay default-constructed (all zeros) — same shape we see on Linux's lo.

--- a/src/reflector/raw_socket.h
+++ b/src/reflector/raw_socket.h
@@ -4,6 +4,7 @@
 #include "link_socket.h"
 #include "logger.h"
 #include "packet.h"
+#include "platform.h"
 #include "util/address_family_pair.h"
 #include "util/no_move.h"
 #include "util/unique_fd.h"
@@ -85,7 +86,7 @@ public:
     // on the next read event.
     [[nodiscard]] std::optional<Packet> Receive() noexcept override;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // True if there are unparsed bytes in the socket's userland buffer. macOS BPF batches
     // multiple frames per read() into our buffer; if the drain stops before the batch is
     // consumed, kqueue won't fire again (the kernel side is empty) and the remaining frames
@@ -116,7 +117,7 @@ private:
     [[nodiscard]] bool SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t src_port,
         std::span<const std::byte> payload, uint8_t ttl) noexcept;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // Discards any unparsed bytes in the userland receive buffer. Called only by Close(), so a socket
     // that closes mid-batch never leaves a stale partial batch behind. The dispatcher fully drains each
     // read event (it loops while HasBufferedData), so there is no abandoned-drain path that needs this.
@@ -141,7 +142,7 @@ private:
     //   walked through the batch.
     std::vector<std::byte> receive_buffer_;
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     size_t receive_buffer_filled_ = 0;
     size_t receive_buffer_offset_ = 0;
 

--- a/src/reflector/tcp_socket.cpp
+++ b/src/reflector/tcp_socket.cpp
@@ -3,6 +3,7 @@
 #include "error.h"
 #include "interface.h"
 #include "logger.h"
+#include "platform.h"
 #include "util/fd_util.h"
 #include "util/narrow_cast.h"
 
@@ -25,13 +26,14 @@ Logger& GetLogger() noexcept {
 }
 
 // Make `fd` non-blocking and SIGPIPE-safe. On Linux SIGPIPE is suppressed per-send via MSG_NOSIGNAL, so
-// only the non-blocking flag is set here; on macOS there is no MSG_NOSIGNAL, so SO_NOSIGPIPE is set once.
+// only the non-blocking flag is set here; on the BSDs the send path passes no such flag, so SO_NOSIGPIPE
+// is set once here instead.
 [[nodiscard]] bool ConfigureFd(int fd) noexcept {
     if (!SetNonBlocking(fd)) {
         GetLogger().Error("Cannot set socket non-blocking: {}", Error::FromErrno());
         return false;
     }
-#if defined(__APPLE__)
+#if !defined(__linux__)
     const int on = 1;
     if (::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on)) != 0) {
         GetLogger().Error("Cannot set SO_NOSIGPIPE: {}", Error::FromErrno());
@@ -43,7 +45,9 @@ Logger& GetLogger() noexcept {
 
 // Pin egress to `egress_if` so the connect leaves via that interface even if a host route would
 // otherwise send it elsewhere (SO_BINDTODEVICE on Linux — needs CAP_NET_RAW; IP_BOUND_IF on macOS).
-[[nodiscard]] bool PinEgress(int fd, [[maybe_unused]] int family, const Interface& egress_if) noexcept {
+// FreeBSD has neither, so it relies on the caller's source-address bind (below) to steer egress.
+[[nodiscard]] bool PinEgress([[maybe_unused]] int fd, [[maybe_unused]] int family,
+        const Interface& egress_if) noexcept {
 #if defined(__linux__)
     const auto name = egress_if.Name();
     if (::setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, name.data(), narrow_cast<socklen_t>(name.size())) != 0) {
@@ -58,6 +62,13 @@ Logger& GetLogger() noexcept {
         GetLogger().Error("Cannot pin egress to interface index {}: {}", ifindex, Error::FromErrno());
         return false;
     }
+#else
+    // No egress-pin socket option on FreeBSD (no SO_BINDTODEVICE, no IP_BOUND_IF). Egress is steered by
+    // the source-address bind the caller performs before connect() (and, for link-local IPv6, the scope
+    // id in the destination sockaddr). Correct when the peer is on a directly-connected subnet of
+    // egress_if — the route to it then leaves via egress_if anyway; otherwise the routing table decides.
+    GetLogger().Debug("No egress-pin primitive; relying on source-address bind to reach via \"{}\"",
+        egress_if.Name());
 #endif
     return true;
 }
@@ -229,7 +240,7 @@ std::optional<TcpSocket> TcpSocket::Accept() noexcept {
         }
         return std::nullopt;
     }
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // accept() does not inherit non-blocking; set it (+ SO_NOSIGPIPE). accept4 already did on Linux.
     if (!ConfigureFd(client)) {
         ::close(client);
@@ -299,8 +310,8 @@ IoResult TcpSocket::WriteSome(std::span<const std::byte> data) noexcept {
     if (IsWouldBlockErrno(errno)) {
         return {IoStatus::WouldBlock, 0};
     }
-#if defined(__APPLE__)
-    // A write to a still-connecting socket returns ENOTCONN on macOS (Linux returns EWOULDBLOCK, handled
+#if !defined(__linux__)
+    // A write to a still-connecting socket returns ENOTCONN on the BSDs (Linux returns EWOULDBLOCK, handled
     // above). Only while connecting does it mean "not ready yet": treat it as WouldBlock so the tail buffers
     // and the connect-completion writable edge flushes it, matching Linux. Gated on connecting_ so an
     // ENOTCONN on an established socket stays a real Error; a failed connect is still caught by FinishConnect.
@@ -345,7 +356,7 @@ IoResult TcpSocket::WriteSomeV(std::span<const std::span<const std::byte>> chunk
     if (IsWouldBlockErrno(errno)) {
         return {IoStatus::WouldBlock, 0};
     }
-#if defined(__APPLE__)
+#if !defined(__linux__)
     if (connecting_ && errno == ENOTCONN) {  // still-connecting socket — see WriteSome's note
         return {IoStatus::WouldBlock, 0};
     }

--- a/tests/default_address_monitor_test.cpp
+++ b/tests/default_address_monitor_test.cpp
@@ -20,7 +20,7 @@
 #if defined(__linux__)
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#elif defined(__APPLE__)
+#else
 #include <net/if.h>
 #include <net/route.h>
 #endif
@@ -58,7 +58,7 @@ constexpr uint16_t ADDR_MESSAGE = RTM_NEWADDR;
 constexpr uint16_t DELETED_ADDR_MESSAGE = RTM_DELADDR;
 constexpr uint16_t NON_ADDR_MESSAGE = RTM_NEWLINK;
 
-#elif defined(__APPLE__)
+#else
 
 // Appends one PF_ROUTE message (ifa_msghdr) of the given type carrying ifam_index. The parser
 // reads ifam_msglen/ifam_type from the rt_msghdr-shared prefix and ifam_index from the

--- a/tests/frame_builder_test.cpp
+++ b/tests/frame_builder_test.cpp
@@ -149,7 +149,7 @@ TEST(FrameBuilderTest, EthernetIpv6) {
     EXPECT_TRUE(std::equal(udp.begin() + 8, udp.end(), payload.begin()));  // payload
 }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 TEST(FrameBuilderTest, LoopbackIpv4) {
     const auto src_ip = IpAddress::FromV4Bytes(127, 0, 0, 1);
     const auto dst_ip = *IpAddress::FromString("224.0.0.251");

--- a/tests/interface_address_test.cpp
+++ b/tests/interface_address_test.cpp
@@ -39,10 +39,22 @@ TEST(InterfaceAddressTest, ResolvesLoopbackIpv4) {
     EXPECT_EQ(addresses.mac, MacAddress{});  // loopback has no link-layer address
 }
 
-#if defined(__APPLE__)
+#if defined(__linux__)
 
-// macOS lo0 carries a link-local fe80::1, which the resolver prefers; verify the BSD-embedded
-// scope id (bytes 2-3) is cleared so the source is the canonical fe80::1.
+// Linux lo has only ::1 (no link-local); verify we resolve that loopback address — the lowest
+// Ipv6Rank fallback — rather than nothing, and don't fabricate an fe80::.
+TEST(InterfaceAddressTest, ResolvesLoopbackIpv6) {
+    const auto addresses = ResolveLoopback();
+    if (!addresses.v6) {
+        GTEST_SKIP() << "loopback has no IPv6 on this host";
+    }
+    EXPECT_EQ(*addresses.v6, IpAddress::LoopbackV6());
+}
+
+#else
+
+// macOS and FreeBSD lo0 carry a link-local fe80::1, which the resolver prefers; verify the
+// BSD-embedded scope id (bytes 2-3) is cleared so the source is the canonical fe80::1.
 TEST(InterfaceAddressTest, ResolvesLoopbackLinkLocalIpv6) {
     const auto addresses = ResolveLoopback();
     if (!addresses.v6) {
@@ -53,18 +65,6 @@ TEST(InterfaceAddressTest, ResolvesLoopbackLinkLocalIpv6) {
     EXPECT_EQ(std::to_integer<uint8_t>(bytes[1]) & 0xc0, 0x80);
     EXPECT_EQ(std::to_integer<uint8_t>(bytes[2]), 0);  // embedded scope id cleared
     EXPECT_EQ(std::to_integer<uint8_t>(bytes[3]), 0);
-}
-
-#elif defined(__linux__)
-
-// Linux lo has only ::1 (no link-local); verify we resolve that loopback address — the lowest
-// Ipv6Rank fallback — rather than nothing, and don't fabricate an fe80::.
-TEST(InterfaceAddressTest, ResolvesLoopbackIpv6) {
-    const auto addresses = ResolveLoopback();
-    if (!addresses.v6) {
-        GTEST_SKIP() << "loopback has no IPv6 on this host";
-    }
-    EXPECT_EQ(*addresses.v6, IpAddress::LoopbackV6());
 }
 
 #endif

--- a/tests/ip_address_test.cpp
+++ b/tests/ip_address_test.cpp
@@ -251,7 +251,7 @@ TEST(IpAddressTest, ToSockaddrV4RoundTrips) {
     const auto* v4 = reinterpret_cast<const sockaddr_in*>(&storage);
     EXPECT_EQ(ntohs(v4->sin_port), 7);
     EXPECT_EQ(IpAddress::FromSockaddr(reinterpret_cast<const sockaddr*>(&storage)), addr);
-#if defined(__APPLE__)
+#if !defined(__linux__)
     EXPECT_EQ(v4->sin_len, sizeof(sockaddr_in));  // BSD sockaddr length, needed by MCAST_JOIN_GROUP
 #endif
 }
@@ -266,7 +266,7 @@ TEST(IpAddressTest, ToSockaddrV6RoundTripsWithScopeId) {
     EXPECT_EQ(ntohs(v6->sin6_port), 9);
     EXPECT_EQ(v6->sin6_scope_id, 42u);
     EXPECT_EQ(IpAddress::FromSockaddr(reinterpret_cast<const sockaddr*>(&storage)), addr);
-#if defined(__APPLE__)
+#if !defined(__linux__)
     EXPECT_EQ(v6->sin6_len, sizeof(sockaddr_in6));  // BSD sockaddr length, needed by MCAST_JOIN_GROUP
 #endif
 }

--- a/tests/mocks/fake_link_socket.h
+++ b/tests/mocks/fake_link_socket.h
@@ -43,7 +43,7 @@ struct FakeLinkSocket : LinkSocket {
     [[nodiscard]] bool IsValid() const noexcept override { return valid; }
     [[nodiscard]] int Fd() const noexcept override { return fd; }
     [[nodiscard]] std::optional<Packet> Receive() noexcept override { return std::nullopt; }
-#if defined(__APPLE__)
+#if !defined(__linux__)
     [[nodiscard]] bool HasBufferedData() const noexcept override { return false; }
 #endif
 

--- a/tests/raw_socket_test.cpp
+++ b/tests/raw_socket_test.cpp
@@ -35,10 +35,10 @@ constexpr uint16_t INJECT_SRC_PORT = 40000;
 constexpr uint16_t INJECT_DST_PORT = 40009;
 
 // Creates a connected virtual-interface pair for the test's lifetime (veth on Linux, feth on
-// macOS) so a frame injected on the first interface is received on the second. Needs root
-// (interface creation is CAP_NET_ADMIN), so IsValid() is false otherwise — and on any setup
-// failure — for callers to GTEST_SKIP. We shell out to ip/ifconfig because there is no portable
-// syscall for macOS feth peering. Only interfaces we created are torn down.
+// macOS, epair on FreeBSD) so a frame injected on the first interface is received on the second.
+// Needs root (interface creation is CAP_NET_ADMIN), so IsValid() is false otherwise — and on any
+// setup failure — for callers to GTEST_SKIP. We shell out to ip/ifconfig because there is no
+// portable syscall for the BSD pair peering. Only interfaces we created are torn down.
 class InterfacePair {
 public:
     InterfacePair() {
@@ -84,6 +84,20 @@ public:
             && Run("ifconfig " + inject_ + " inet6 fe80::1 prefixlen 64")
             && Run("ifconfig " + receive_ + " up")
             && Run("ifconfig " + receive_ + " inet6 fe80::2 prefixlen 64");
+#elif defined(__FreeBSD__)
+        // epair creates a connected pair in one call: `ifconfig epair create` prints the 'a' end
+        // (e.g. epair0a); the peer is the same name with a trailing 'b'.
+        inject_ = RunCapture("ifconfig epair create");
+        if (inject_.empty()) {
+            return;
+        }
+        created_ = true;  // destroying the 'a' end removes both
+        receive_ = inject_;
+        receive_.back() = 'b';
+        valid_ = Run("ifconfig " + inject_ + " inet 10.99.0.1/24 up")
+            && Run("ifconfig " + inject_ + " inet6 fe80::1 prefixlen 64")
+            && Run("ifconfig " + receive_ + " up")
+            && Run("ifconfig " + receive_ + " inet6 fe80::2 prefixlen 64");
 #endif
         if (!valid_) {
             Destroy();
@@ -105,9 +119,9 @@ private:
         return std::system((command + " >/dev/null 2>&1").c_str()) == 0;
     }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // Runs `command` and returns its stdout with trailing whitespace trimmed (empty on failure) —
-    // used to capture the interface name `ifconfig feth create` prints.
+    // used to capture the interface name `ifconfig feth/epair create` prints.
     static std::string RunCapture(const std::string& command) {
         std::string output;
         FILE* pipe = ::popen((command + " 2>/dev/null").c_str(), "r");
@@ -138,17 +152,21 @@ private:
         if (created_receive_) {
             Run("ifconfig " + receive_ + " destroy");
         }
+#elif defined(__FreeBSD__)
+        if (created_) {
+            Run("ifconfig " + inject_ + " destroy");  // removes both ends of the epair
+        }
 #endif
     }
 
     // assigned at construction (unique per process / kernel-assigned)
     std::string inject_;
     std::string receive_;
-#if defined(__linux__)
-    bool created_ = false;
-#elif defined(__APPLE__)
+#if defined(__APPLE__)
     bool created_inject_ = false;
     bool created_receive_ = false;
+#else
+    bool created_ = false;
 #endif
     bool valid_ = false;
 };
@@ -175,7 +193,7 @@ protected:
     FakeInterface iface{"test", 0, {}};
     RawSocket socket{RawSocket::ForTesting(iface, -1)};
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     using LinkType = RawSocket::LinkType;
     void SetLinkType(LinkType link_type) noexcept { socket.link_type_ = link_type; }
 #endif
@@ -486,8 +504,8 @@ TEST_F(RawSocketTest, JoinMulticastGroupRejectsNonMulticastAddress) {
     EXPECT_FALSE(JoinFdValid(IpAddress::Family::V6));
 }
 
-#if defined(__APPLE__)
-// DLT_NULL is macOS-only — on Linux AF_PACKET delivers Ethernet frames for every
+#if !defined(__linux__)
+// DLT_NULL framing only appears on the BSDs — on Linux AF_PACKET delivers Ethernet frames for every
 // interface, lo included, so the parser never encounters loopback framing there.
 TEST_F(RawSocketTest, ParsesLoopbackIpv4UdpWithZeroMacs) {
     SetLinkType(LinkType::Loopback);
@@ -660,7 +678,7 @@ TEST(RawSocketBatchTest, ReceiveDropsBpfTruncatedFrame) {
     });
     EXPECT_NE(output.find("oversized frame"), std::string::npos) << output;
 }
-#endif  // defined(__APPLE__)
+#endif  // !defined(__linux__)
 
 #if defined(__linux__)
 // recv(MSG_TRUNC) reports an oversized frame's real length, so Receive drops it (with a warning)
@@ -742,20 +760,20 @@ TEST_F(RawSocketRequiresRootTest, DrainsBatchedFramesFromOneRead) {
         ASSERT_TRUE(sender_socket.SendTo(payload, {IpAddress::LoopbackV4(), listener_port}));
     }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     bool observed_buffered_read = false;
 #endif
     for (int i = 0; i < packet_count; ++i) {
         const auto packet = ReceiveOurDatagram();
         ASSERT_TRUE(packet.has_value()) << "missing packet " << (i + 1);
-#if defined(__APPLE__)
+#if !defined(__linux__)
         if (socket->HasBufferedData()) {
             observed_buffered_read = true;
         }
 #endif
     }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     EXPECT_TRUE(observed_buffered_read)
         << "Expected at least one Receive() to leave userland-buffered data behind — "
            "the macOS multi-frame BPF batch walk was not exercised";
@@ -786,12 +804,13 @@ TEST_F(RawSocketRequiresRootTest, InjectsUdpDatagram) {
 // captures it (the BPF filter drops only the outgoing copy, so the looped-back broadcast
 // survives), verifying the on-the-wire frame's source/destination and payload.
 //
-// Linux only — compiled out of the macOS build rather than skipped at runtime: macOS never loops
-// BPF-injected frames on lo0 back to the input path (the same reason pcap_inject on lo0 is a no-op
-// there; confirmed that neither a UDP socket nor the injecting BPF device itself observes them), so
-// this can never run there. The macOS inject path is asserted by InjectsUdpDatagram above and its
-// framing by the frame-builder tests.
-#if defined(__linux__)
+// Everywhere but macOS — compiled out of the macOS build rather than skipped at runtime: macOS never
+// loops BPF-injected frames on lo0 back to the input path (the same reason pcap_inject on lo0 is a
+// no-op there; confirmed that neither a UDP socket nor the injecting BPF device itself observes
+// them), so this can never run there. The macOS inject path is asserted by InjectsUdpDatagram above
+// and its framing by the frame-builder tests. Linux loops back via its Ethernet lo and FreeBSD via
+// if_simloop, so the round trip completes on both.
+#if !defined(__APPLE__)
 TEST_F(RawSocketRequiresRootTest, CapturesInjectedDatagramOnLoopback) {
     const std::array payload{std::byte{0xca}, std::byte{0xfe}, std::byte{0xba}, std::byte{0xbe}};
 
@@ -881,7 +900,7 @@ protected:
 #if defined(__linux__)
             const auto addresses =
                 ResolveInterfaceAddresses(if_nametoindex(pair.ReceiveInterface().c_str()));
-#elif defined(__APPLE__)
+#else
             const auto addresses = ResolveInterfaceAddresses(pair.ReceiveInterface());
 #endif
             if (addresses.v6 && addresses.v6->IsLinkLocal()) {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
 #include <net/bpf.h>
 #endif
 
@@ -159,12 +159,12 @@ inline uint16_t BindLoopback(UdpSocket& socket, uint16_t port = 0) {
     return bound_port;
 }
 
-// Loopback interface name varies by OS; "lo" on Linux, "lo0" on macOS.
+// Loopback interface name varies by OS; "lo" on Linux, "lo0" on macOS and FreeBSD.
 inline std::string_view LoopbackInterface() noexcept {
-#if defined(__APPLE__)
-    return "lo0";
-#else
+#if defined(__linux__)
     return "lo";
+#else
+    return "lo0";
 #endif
 }
 
@@ -318,7 +318,7 @@ struct TestCaptureSocket {
         return WriteRaw(EncodeFrame(frame));
     }
 
-#if defined(__APPLE__)
+#if !defined(__linux__)
     // Packs multiple frames into a single BPF batch so one read() returns all of them and
     // Receive's batch walker steps through them on successive calls. macOS-only because
     // Linux's AF_PACKET preserves message boundaries — a Linux multi-frame "batch" would
@@ -363,7 +363,7 @@ private:
     // original_length sets bh_datalen; pass a value larger than frame.size() to model a frame BPF
     // truncated to fit the buffer. Ignored on Linux, which has no bpf_hdr.
     static std::vector<std::byte> EncodeFrame(std::span<const std::byte> frame, [[maybe_unused]] uint32_t original_length) {
-#if defined(__APPLE__)
+#if !defined(__linux__)
         bpf_hdr header{};
         header.bh_hdrlen = static_cast<u_short>(BPF_WORDALIGN(sizeof(bpf_hdr)));
         header.bh_caplen = static_cast<bpf_u_int32>(frame.size());

--- a/tests/util/udp_socket.cpp
+++ b/tests/util/udp_socket.cpp
@@ -89,6 +89,9 @@ bool UdpSocket::SetInterface(const std::string& interface) {
                       interface, idx, Error::FromErrno());
         return false;
     }
+#else
+    // FreeBSD has no egress-pin socket option (no SO_BINDTODEVICE / IP_BOUND_IF); rely on the routing
+    // table, mirroring the production TcpSocket source-bind fallback. interface_index_ is still recorded.
 #endif
 
     interface_index_ = idx;


### PR DESCRIPTION
Adds FreeBSD as a supported platform — build, run, unit CI, and static release binaries. Minor bump to 0.6.0 (new platform, backward-compatible, no breaking changes).

## Approach
FreeBSD shares its BSD platform path with macOS (kqueue, BPF capture/inject, PF_ROUTE address monitoring, getifaddrs, MCAST_JOIN_GROUP). Rather than add a third branch everywhere, the platform guards are flipped so **Linux is the outlier** (`#if defined(__linux__) ... #else ...`) and FreeBSD rides the existing BSD code. A single `platform.h` gate replaces the three per-file `#error` traps.

## FreeBSD-specific points the flip surfaced
- **`PinEgress`** (DIAL/TCP egress): FreeBSD has neither `IP_BOUND_IF` nor `SO_BINDTODEVICE`, so it falls back to the source-address bind `Connect` already does.
- **`SO_NOSIGPIPE`** and the **`ENOTCONN`-while-connecting** handling are BSD-wide, not macOS-only.
- `sin_len`/`sin6_len` (`sa_len`) is set on FreeBSD.
- The signal handler narrows the wakeup fd explicitly — `std::sig_atomic_t` is wider than `int` on FreeBSD (`long`).

## Build
- 0.6.0; `CMAKE_SYSTEM_NAME=FreeBSD` accepted in the platform gate.
- C++ module dependency scanning disabled — the project uses `#include`, not modules, and its Clang path needs `clang-scan-deps`, which FreeBSD's base clang doesn't ship.
- `REFLECTOR_STATIC` now supported on FreeBSD too (NSS-free → a `-static` binary is self-contained), still mutually exclusive with the sanitizers and unsupported on macOS.

## Tests
Harness ported to FreeBSD: `epair` interface pairs (vs veth/feth), `lo0` loopback name, the fake link-socket `HasBufferedData` override, and the DLT_NULL / sa_len / PF_ROUTE / bpf_hdr test guards aligned with the src flip. The loopback inject→capture round trip now runs everywhere but macOS (FreeBSD re-injects BPF writes via `if_simloop`, Linux loops back via its Ethernet `lo`; macOS does not).

## CI
New `freebsd` job boots FreeBSD 14.2 via `vmactions/freebsd-vm` and builds + ctests Debug and Release with base clang/libc++ 18, as root so the `RequiresRoot` tests (BPF capture, epair pairs) run. Release builds **static** (the config we ship); Debug stays dynamic to carry ASan/UBSan — the same split as the Linux lanes. Packages are upgraded first (`pkg upgrade -y`) so the catalogue's `git` loads against a matching pcre2.

## Release binaries
FreeBSD can't be a Docker target (Docker shares the host's Linux kernel), so each release additionally ships standalone **static** FreeBSD binaries for `amd64` and `arm64` (new `binaries-freebsd` job). amd64 builds KVM-accelerated; arm64 has no KVM on any GitHub-hosted runner, so it builds emulated on the (measurably faster) amd64 host. The build asserts the result is statically linked before uploading. The static binaries are verified to run across FreeBSD 13, 14, and 15, so there's one per arch with no per-major split.

## Verification
- **macOS / Linux:** behavior-preserving (the flip routes the same code through `#else`); suites stay green.
- **FreeBSD:** unit CI is green for both Debug and Release; the static binary built on 14.2 runs the full suite on 13.5, 14.2, and 15.0 with no ABI/exec warnings.

DLT_NULL loopback **emit** was investigated for removal and kept (macOS parity) — no behavior change there.
