### PR TITLE
ci: Linux Release lanes static; derive static/sanitize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             cxx: arm-linux-gnueabihf-g++-14
             crosscompile: true
             cross_packages: crossbuild-essential-armhf g++-14-arm-linux-gnueabihf gcc-14-arm-linux-gnueabihf qemu-user-static
-            cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm -D REFLECTOR_STATIC=ON -D REFLECTOR_SANITIZE=OFF -D CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-arm-static
+            cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm -D CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-arm-static
           - variant: linux-armv5
             runner: ubuntu-24.04
             platform: linux
@@ -56,7 +56,7 @@ jobs:
             cxx: arm-linux-gnueabi-g++-14
             crosscompile: true
             cross_packages: crossbuild-essential-armel g++-14-arm-linux-gnueabi gcc-14-arm-linux-gnueabi qemu-user-static
-            cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm -D REFLECTOR_STATIC=ON -D REFLECTOR_SANITIZE=OFF -D CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-arm-static
+            cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm -D CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-arm-static
           - variant: macos-arm64
             runner: macos-15
             platform: macos
@@ -91,10 +91,20 @@ jobs:
         env:
           CXX: ${{ matrix.cxx }}
 
+      # Release is the static config we ship (REFLECTOR_STATIC); Debug stays dynamic so it can carry
+      # ASan/UBSan — the two are mutually exclusive. macOS has no static libSystem, so it is never
+      # static (its Debug keeps the sanitizers, its Release is plain dynamic). The cross lanes run under
+      # qemu-user with no target sysroot, so they build static (no runtime libs to find) and unsanitized
+      # (no target ASan/UBSan runtime) in both configs.
       - name: Configure
         run: |
+          if [ "${{ matrix.build_type }}" = Release ]; then static=ON; sanitize=OFF; else static=OFF; sanitize=ON; fi
+          if [ "${{ matrix.platform }}" = macos ]; then static=OFF; fi
+          if [ "${{ matrix.crosscompile }}" = true ]; then static=ON; sanitize=OFF; fi
           cmake -S . -B build -G Ninja \
             -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -D REFLECTOR_STATIC=$static \
+            -D REFLECTOR_SANITIZE=$sanitize \
             ${{ matrix.cmake_args }}
         env:
           CC: ${{ matrix.cc }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,22 +58,19 @@ jobs:
             platform: linux
             cc: gcc-14
             cxx: g++-14
-            reflector_static: "ON"
           - variant: linux-arm64
             runner: ubuntu-24.04-arm
             platform: linux
             cc: gcc-14
             cxx: g++-14
-            reflector_static: "ON"
           # armv7/armv5 have no native runner: cross-compile on the amd64 runner. cross_packages adds the
-          # toolchain; cmake_args drives CMAKE_SYSTEM_* (CC/CXX point at the cross compilers). Same matrix-
-          # field approach as ci.yml. armv7 = armhf (hard-float); armv5 = armel (soft-float, EN7562 boxes).
+          # toolchain; cmake_args drives CMAKE_SYSTEM_* (CC/CXX point at the cross compilers). Same cross-
+          # compile setup as ci.yml. armv7 = armhf (hard-float); armv5 = armel (soft-float, EN7562 boxes).
           - variant: linux-armv7
             runner: ubuntu-24.04
             platform: linux
             cc: arm-linux-gnueabihf-gcc-14
             cxx: arm-linux-gnueabihf-g++-14
-            reflector_static: "ON"
             cross_packages: crossbuild-essential-armhf g++-14-arm-linux-gnueabihf gcc-14-arm-linux-gnueabihf
             cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm
           - variant: linux-armv5
@@ -81,7 +78,6 @@ jobs:
             platform: linux
             cc: arm-linux-gnueabi-gcc-14
             cxx: arm-linux-gnueabi-g++-14
-            reflector_static: "ON"
             cross_packages: crossbuild-essential-armel g++-14-arm-linux-gnueabi gcc-14-arm-linux-gnueabi
             cmake_args: -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=arm
           - variant: macos-arm64
@@ -89,7 +85,6 @@ jobs:
             platform: macos
             cc: clang
             cxx: clang++
-            reflector_static: "OFF"  # macOS has no static libSystem; ships dynamic against the system libs
 
     steps:
       - name: Check out repository
@@ -106,17 +101,19 @@ jobs:
         if: matrix.platform == 'macos'
         run: brew list ninja >/dev/null 2>&1 || brew install ninja
 
+      # Every release binary is static (REFLECTOR_STATIC) except macOS, which has no static libSystem and
+      # ships dynamic against the system libs — derive it from the platform.
       - name: Configure
         run: |
+          if [ "${{ matrix.platform }}" = macos ]; then static=OFF; else static=ON; fi
           cmake -S . -B build -G Ninja \
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_TESTING=OFF \
-            -D REFLECTOR_STATIC="${REFLECTOR_STATIC}" \
+            -D REFLECTOR_STATIC=$static \
             ${{ matrix.cmake_args }}
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
-          REFLECTOR_STATIC: ${{ matrix.reflector_static }}
 
       - name: Build
         run: cmake --build build --target reflector_app


### PR DESCRIPTION
Makes the native Linux **Release** unit builds static and removes the duplicated, per-variant static/sanitize wiring across both workflows.

## Why
- The amd64/arm64 Release unit lanes built **dynamic**, so the unit suite never exercised the configuration we actually ship (static). Now Release is static.
- `REFLECTOR_STATIC`/`REFLECTOR_SANITIZE` were set inconsistently — per-variant `cmake_args` in `ci.yml`, a dedicated `reflector_static` matrix field in `release.yml`. Both are now derived in the Configure step.

## `ci.yml` (unit job)
Static/sanitize derived from `build_type` + platform:

| variant | Debug | Release |
|---|---|---|
| linux-amd64 / arm64 | dynamic + sanitized | **static** *(was dynamic)* |
| linux-armv7 / armv5 | static, no-sanitize | static, no-sanitize |
| macos-arm64 | dynamic + sanitized | dynamic, no-sanitize |

- macOS is never static (no static libSystem); its Debug keeps ASan/UBSan.
- The qemu-user cross lanes stay static + unsanitized in both configs (no target sysroot / sanitizer runtime). Their `cmake_args` now carry only the toolchain + emulator.
- Only behavior change: **amd64/arm64 Release → static**. Debug, cross, and macOS are unchanged.

## `release.yml` (binaries job)
Every release binary is static except macOS — derived from platform, dropping the `reflector_static` matrix field. No change to which binaries are static (Linux ON, macOS OFF as before).

Independent of the FreeBSD work (#15); branched off `main`.
