### PR TITLE
test: de-flake the veth broadcast-capture test (wait for link bring-up)

### DIFF
--- a/tests/raw_socket_test.cpp
+++ b/tests/raw_socket_test.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <ifaddrs.h>
 #include <net/if.h>
 #include <optional>
 #include <poll.h>
@@ -101,7 +102,13 @@ public:
 #endif
         if (!valid_) {
             Destroy();
+            return;
         }
+        // A freshly-created veth/feth pair drops frames until both ends finish coming up: the kernel
+        // accepts an injected frame for transmission, but the device discards it while the carrier is
+        // still settling, with no retransmit. Wait for both ends to report running so a send-once test
+        // doesn't race that warm-up window.
+        WaitUntilRunning();
     }
 
     InterfacePair(const InterfacePair&) = delete;
@@ -117,6 +124,35 @@ private:
     static bool Run(const std::string& command) {
         // POSIX std::system returns the wait status; a command that exits 0 yields 0.
         return std::system((command + " >/dev/null 2>&1").c_str()) == 0;
+    }
+
+    // True once `ifname` is administratively up and the link layer reports it running (carrier up).
+    // getifaddrs is portable across Linux/macOS/FreeBSD and every interface appears in it (the flags
+    // are the same across an interface's entries), so one pass suffices.
+    static bool LinkRunning(const std::string& ifname) {
+        ifaddrs* addrs = nullptr;
+        if (::getifaddrs(&addrs) != 0) {
+            return false;
+        }
+        bool running = false;
+        for (const ifaddrs* it = addrs; it != nullptr; it = it->ifa_next) {
+            if (it->ifa_name != nullptr && ifname == it->ifa_name) {
+                running = (it->ifa_flags & IFF_UP) != 0 && (it->ifa_flags & IFF_RUNNING) != 0;
+                break;
+            }
+        }
+        ::freeifaddrs(addrs);
+        return running;
+    }
+
+    // Best-effort wait until both ends are running (see the constructor). If the budget elapses we
+    // proceed anyway, so a stuck link surfaces as a loud test failure rather than a silent skip.
+    void WaitUntilRunning() const {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{3};
+        while (!(LinkRunning(inject_) && LinkRunning(receive_))
+                && std::chrono::steady_clock::now() < deadline) {
+            ::poll(nullptr, 0, POLL_SLICE_MS);
+        }
     }
 
 #if !defined(__linux__)


### PR DESCRIPTION
De-flakes `RawSocketInterfacePairRequiresRootTest` by waiting for a freshly-created interface pair to actually come up before the first injection.

## Symptom
`RawSocketInterfacePairRequiresRootTest.InjectsIpv4BroadcastCapturedOnPeer` intermittently failed with "peer did not capture the injected broadcast" (the 2s capture budget fully elapsed). It surfaced on the busier `linux-amd64 Release` lane; the same config passed on `linux-arm64`, on macOS, and on prior runs — i.e. a timing flake, not a logic or static-linking regression.

## Root cause
The test injects **one** IPv4 broadcast on a just-created veth pair and waits for the peer to capture it. The kernel accepts the frame for transmission (`sendto` succeeds, so the send-assert passes), but a veth device **silently discards frames until its carrier finishes coming up**, with no retransmit. If the runner is loaded enough that the link hasn't settled when that single frame goes out, it's lost and the capture times out.

The asymmetry across the suite confirms it:

| test | interface | waits for link before sending? | flaked? |
|---|---|---|---|
| `InjectsIpv4BroadcastCapturedOnPeer` | fresh veth/epair | **no** — IPv4 source is ready instantly (no DAD), sends immediately | **yes** |
| `InjectsIpv6MulticastReceivedByUdpSocket` | fresh veth/epair | yes — `WaitForSource` + `WaitForReceiverLinkLocal` poll-loops (for IPv6 DAD) incidentally wait out the same window | no |
| `CapturesInjectedDatagramOnLoopback` | `lo` | n/a — loopback is always up | no |

## Fix
Have `InterfacePair` wait until both ends report `IFF_RUNNING` (carrier up) before handing the pair to a test, so the first send isn't racing link bring-up. On veth, `IFF_RUNNING` ⟺ operstate-up ⟺ carrier-up, so once it's set `veth_xmit` delivers to the peer — the single send lands, no change to the test's "send once, capture once" semantics.

- **Best-effort**: if the budget elapses we proceed anyway, so a genuinely stuck link fails loudly rather than skipping or masking a real break.
- **Portable** via `getifaddrs` (Linux/macOS/FreeBSD), placed after the platform-specific setup so every pair test — and every platform, including the FreeBSD epair branch — benefits.

## Validation
Full CI on this branch is green across all 15 lanes — unit (incl. the previously-flaky `linux-amd64 Release` and the FreeBSD Debug/Release lanes), Docker e2e, and Valgrind unit + e2e.
