### PR TITLE
refactor: store borrowed dependencies as pointers, not reference members

### DIFF
--- a/src/reflector/dial_proxy.cpp
+++ b/src/reflector/dial_proxy.cpp
@@ -18,9 +18,9 @@ namespace reflector {
 DialProxy::DialProxy(Dispatcher& dispatcher, const Interface& source_if, const Interface& target_if,
     std::string logger_name)
         : logger_{std::move(logger_name)}
-        , dispatcher_{dispatcher}
-        , source_if_{source_if}
-        , target_if_{target_if}
+        , dispatcher_{&dispatcher}
+        , source_if_{&source_if}
+        , target_if_{&target_if}
         , eviction_timer_{dispatcher} {}
 
 std::optional<IpEndpoint> DialProxy::EnsureDiscoveryListener(const IpEndpoint& device) {
@@ -28,18 +28,18 @@ std::optional<IpEndpoint> DialProxy::EnsureDiscoveryListener(const IpEndpoint& d
 }
 
 void DialProxy::OnInterfaceChanged() noexcept {
-    const auto current = source_if_.SourceAddress(IpAddress::Family::V4);
+    const auto current = source_if_->SourceAddress(IpAddress::Family::V4);
 
     // A listener is stale when its bind address no longer matches source_if's current V4 source — the
     // address changed under it, or vanished (current == nullopt makes every listener stale). Drop the
-    // connections pinned to a stale endpoint FIRST: a Connection borrows Endpoint& and its dtor
+    // connections pinned to a stale endpoint FIRST: a Connection borrows an Endpoint* and its dtor
     // decrements that endpoint's active_connections, so erasing the endpoint with a live connection
-    // still pinned would dangle the reference. The predicate is the same on both sweeps, so a dropped
+    // still pinned would dangle the pointer. The predicate is the same on both sweeps, so a dropped
     // connection's endpoint is always among the endpoints dropped below.
     const auto is_stale = [&current](const Endpoint& endpoint) {
         return current != endpoint.listener.LocalEndpoint().addr;
     };
-    std::erase_if(connections_, [&](const auto& entry) { return is_stale(entry.second.endpoint); });
+    std::erase_if(connections_, [&](const auto& entry) { return is_stale(*entry.second.endpoint); });
     const auto dropped = std::erase_if(endpoints_, [&](const auto& entry) { return is_stale(entry.second); });
 
     if (dropped > 0) {
@@ -87,7 +87,7 @@ std::optional<IpEndpoint> DialProxy::EnsureListener(const IpEndpoint& device, En
         return std::nullopt;
     }
 
-    auto listener = TcpSocket::Listen(source_if_, IpAddress::Family::V4);
+    auto listener = TcpSocket::Listen(*source_if_, IpAddress::Family::V4);
     if (!listener) {
         logger_.Error("Cannot proxy {}: failed to open a listener", device);  // Listen logged the cause
         return std::nullopt;
@@ -100,7 +100,7 @@ std::optional<IpEndpoint> DialProxy::EnsureListener(const IpEndpoint& device, En
     const auto [it, inserted] = endpoints_.try_emplace(device, device, role, std::move(*listener), now);
     auto& endpoint = it->second;
 
-    auto registration = dispatcher_.Register(listener_fd, CreateDelegate<&DialProxy::OnAccept>(this));
+    auto registration = dispatcher_->Register(listener_fd, CreateDelegate<&DialProxy::OnAccept>(this));
     if (!registration.IsValid()) {
         logger_.Error("Cannot proxy {}: failed to register the listener", device);
         endpoints_.erase(it);  // drops the listener (registration was never valid)
@@ -123,8 +123,8 @@ std::optional<IpEndpoint> DialProxy::EnsureListener(const IpEndpoint& device, En
 
 DialProxy::Connection::Connection(DialProxy& proxy, Endpoint& owning_endpoint, TcpSocket client_socket,
     TcpSocket upstream_socket, std::chrono::steady_clock::time_point connect_deadline)
-        : owner{proxy}
-        , endpoint{owning_endpoint}
+        : owner{&proxy}
+        , endpoint{&owning_endpoint}
         , client{std::move(client_socket)}
         , upstream{std::move(upstream_socket)}
         // `this` in a ctor init-list is the object's FINAL address — valid because try_emplace constructs the
@@ -134,11 +134,11 @@ DialProxy::Connection::Connection(DialProxy& proxy, Endpoint& owning_endpoint, T
         , c2u{CreateDelegate<&Connection::RewriteHost>(this)}
         , u2c{CreateDelegate<&Connection::RewriteRestAuthority>(this)}
         , deadline{connect_deadline} {
-    ++endpoint.active_connections;  // refcount against the endpoint; the dtor decrements (RAII eviction count)
+    ++endpoint->active_connections;  // refcount against the endpoint; the dtor decrements (RAII eviction count)
 }
 
 DialProxy::Connection::~Connection() noexcept {
-    --endpoint.active_connections;
+    --endpoint->active_connections;
 }
 
 void DialProxy::Connection::Abort() noexcept {
@@ -150,9 +150,9 @@ void DialProxy::Connection::Abort() noexcept {
 }
 
 void DialProxy::Connection::Sync(TcpSocket& sock) noexcept {
-    if (!owner.dispatcher_.SetWriteInterest(sock.Fd(), sock.WantsWrite())) {
-        owner.logger_.Error("Cannot set write interest for fd {} (device {}); aborting connection",
-            sock.Fd(), endpoint.device);
+    if (!owner->dispatcher_->SetWriteInterest(sock.Fd(), sock.WantsWrite())) {
+        owner->logger_.Error("Cannot set write interest for fd {} (device {}); aborting connection",
+            sock.Fd(), endpoint->device);
         Abort();
     }
 }
@@ -262,7 +262,7 @@ std::optional<IpEndpoint> DialProxy::Connection::RewriteRestAuthority(const IpEn
                               // re-enter EnsureRestListener (Listen+Register) to mint a listener the dropped
                               // message will never deliver.
     }
-    const auto authority = owner.EnsureRestListener(found);
+    const auto authority = owner->EnsureRestListener(found);
     if (!authority) {
         // Close-don't-forward: the device's authority can't be made routable, so drop the connection now.
         // Safe from inside Feed — Abort only drops the dispatcher Registrations (PollOnce copied the firing
@@ -298,7 +298,7 @@ void DialProxy::OnAccept(int listener_fd) noexcept {
         return;  // the accepted client TcpSocket drops here -> RAII close
     }
 
-    auto upstream = TcpSocket::Connect(ep->device, &target_if_);
+    auto upstream = TcpSocket::Connect(ep->device, target_if_);
     if (!upstream) {
         logger_.Error("Dropping accept for {}: failed to start the upstream connect", ep->device);
         return;
@@ -316,11 +316,11 @@ void DialProxy::OnAccept(int listener_fd) noexcept {
     // Register both fds into LOCAL Registrations first; only on a clean pair do they move into the
     // Connection. The client is established at accept (WantsWrite() false); the upstream is connecting
     // (WantsWrite() true), so its writable edge is armed to learn of connect-completion.
-    auto client_reg = dispatcher_.Register(client_fd, Dispatcher::FdCallbacks{
+    auto client_reg = dispatcher_->Register(client_fd, Dispatcher::FdCallbacks{
         .read = CreateDelegate<&Connection::OnClientReadable>(&conn),
         .write = CreateDelegate<&Connection::OnClientWritable>(&conn),
         .write_armed = conn.client.WantsWrite()});
-    auto upstream_reg = dispatcher_.Register(upstream_fd, Dispatcher::FdCallbacks{
+    auto upstream_reg = dispatcher_->Register(upstream_fd, Dispatcher::FdCallbacks{
         .read = CreateDelegate<&Connection::OnUpstreamReadable>(&conn),
         .write = CreateDelegate<&Connection::OnUpstreamWritable>(&conn),
         .write_armed = conn.upstream.WantsWrite()});

--- a/src/reflector/dial_proxy.h
+++ b/src/reflector/dial_proxy.h
@@ -137,7 +137,7 @@ private:
         // c2u Host rewrite: the client reached the reflector listener, so its request Host is the reflector
         // authority; always rewrite it to the pinned `device` so the upstream sees itself as Host. The parsed
         // `found` authority is irrelevant — the request always targets the device.
-        std::optional<IpEndpoint> RewriteHost(const IpEndpoint&) noexcept { return endpoint.device; }
+        std::optional<IpEndpoint> RewriteHost(const IpEndpoint&) noexcept { return endpoint->device; }
 
         // u2c Application-URL/Location rewrite: the device names its OWN Rest authority, unroutable across the
         // reflector boundary, so mint (re-entrantly) a reflector Rest listener for it and rewrite to that. A
@@ -158,8 +158,8 @@ private:
         // fds shut down but still open) until the eviction timer reaps it and RAII closes the fds.
         void Abort() noexcept;
 
-        DialProxy& owner;  // reaches owner.dispatcher_ for Sync and owner.EnsureRestListener for the u2c rewrite
-        Endpoint& endpoint;  // the device's endpoint; ctor ++active_connections, dtor -- (eviction refcount)
+        DialProxy* owner;  // reaches owner->dispatcher_ for Sync and owner->EnsureRestListener for the u2c rewrite
+        Endpoint* endpoint;  // the device's endpoint; ctor ++active_connections, dtor -- (eviction refcount)
         TcpSocket client, upstream;
         HttpFraming c2u, u2c;
         StreamBuffer c2u_rx{MAX_RECV_BUFFER}, u2c_rx{MAX_RECV_BUFFER};
@@ -199,9 +199,9 @@ private:
     void EvictExpired(std::chrono::steady_clock::time_point now) noexcept;
 
     Logger logger_;  // "DialProxy:{name}:{src}->{tgt}" — passed in by SsdpReflector
-    Dispatcher& dispatcher_;
-    const Interface& source_if_;
-    const Interface& target_if_;
+    Dispatcher* dispatcher_;
+    const Interface* source_if_;
+    const Interface* target_if_;
 
     // Keyed by the device endpoint via std::hash<IpEndpoint>. Node-stable so a FindEndpointByListenerFd
     // result stays valid across an unrelated mint, and so OnAccept can re-enter EnsureRestListener (which

--- a/src/reflector/mdns_reflector.cpp
+++ b/src/reflector/mdns_reflector.cpp
@@ -21,9 +21,9 @@ MdnsReflector::MdnsReflector(PacketDispatcher& packet_dispatcher, LinkSocket& so
     LinkSocket& target_socket, const MdnsConfig& config)
         : DynamicFamilyReflector{LoggerName(config), source_socket.GetInterface(),
               target_socket.GetInterface(), FamilyCapability::PolicyOf(config)}
-        , source_socket_{source_socket}
-        , target_socket_{target_socket}
-        , packet_dispatcher_{packet_dispatcher}
+        , source_socket_{&source_socket}
+        , target_socket_{&target_socket}
+        , packet_dispatcher_{&packet_dispatcher}
         , config_mac_{config.mac} {
     if (!ValidateConfig(config)) {
         return;
@@ -71,15 +71,15 @@ bool MdnsReflector::BringUpFamily(IpAddress::Family family) {
     // Program gate 2 so each interface actually receives the group's multicast. A failed join or
     // registration drops every token taken here when it leaves scope (auto-leave / auto-unregister),
     // so nothing is half-set-up; the family's setup is only populated on full success.
-    auto source_membership = source_socket_.JoinMulticastGroup(group);
-    auto target_membership = target_socket_.JoinMulticastGroup(group);
+    auto source_membership = source_socket_->JoinMulticastGroup(group);
+    auto target_membership = target_socket_->JoinMulticastGroup(group);
     if (!source_membership.IsValid() || !target_membership.IsValid()) {
         logger_.Error("Cannot reflect mdns {}: cannot join the group on both interfaces", group);
         return false;
     }
 
     // source -> target: relay queries, unfiltered (any client on source may ask).
-    auto source_registration = packet_dispatcher_.Register(source_socket_,
+    auto source_registration = packet_dispatcher_->Register(*source_socket_,
         PacketFilter{.dest_ip = group, .dest_port = MDNS_PORT},
         CreateDelegate<&MdnsReflector::OnSourcePacket>(this));
     if (!source_registration.IsValid()) {
@@ -88,7 +88,7 @@ bool MdnsReflector::BringUpFamily(IpAddress::Family family) {
     }
 
     // target -> source: relay responses, optionally only from the configured device's MAC.
-    auto target_registration = packet_dispatcher_.Register(target_socket_,
+    auto target_registration = packet_dispatcher_->Register(*target_socket_,
         PacketFilter{.dest_ip = group, .dest_port = MDNS_PORT, .source_mac = config_mac_},
         CreateDelegate<&MdnsReflector::OnTargetPacket>(this));
     if (!target_registration.IsValid()) {
@@ -106,14 +106,14 @@ bool MdnsReflector::BringUpFamily(IpAddress::Family family) {
 
 void MdnsReflector::OnSourcePacket(const Packet& packet) noexcept {
     if (ShouldRelay(packet, MdnsMessageKind::Query)) {
-        Relay(target_socket_, packet);
+        Relay(*target_socket_, packet);
     }
 }
 
 void MdnsReflector::OnTargetPacket(const Packet& packet) noexcept {
     // The source-MAC filter is applied by the dispatcher, not here.
     if (ShouldRelay(packet, MdnsMessageKind::Response)) {
-        Relay(source_socket_, packet);
+        Relay(*source_socket_, packet);
     }
 }
 

--- a/src/reflector/mdns_reflector.h
+++ b/src/reflector/mdns_reflector.h
@@ -50,9 +50,9 @@ private:
     [[nodiscard]] bool ShouldRelay(const Packet& packet, MdnsMessageKind kind) noexcept;
     void Relay(LinkSocket& egress, const Packet& packet) noexcept;
 
-    LinkSocket& source_socket_;
-    LinkSocket& target_socket_;
-    PacketDispatcher& packet_dispatcher_;  // retained for dynamic (re-)registration on address changes
+    LinkSocket* source_socket_;
+    LinkSocket* target_socket_;
+    PacketDispatcher* packet_dispatcher_;  // retained for dynamic (re-)registration on address changes
     std::optional<MacAddress> config_mac_;  // device-scoping filter for the target->source capture
 };
 

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -167,8 +167,8 @@ constexpr size_t LOOPBACK_FAMILY_SIZE = 4;
 
 RawSocket::RawSocket(const Interface& interface)
         : logger_{std::format("RawSocket:{}", interface.Name())}
-        , interface_{interface} {
-    if (!interface_.IsValid()) {
+        , interface_{&interface} {
+    if (!interface_->IsValid()) {
         logger_.Error("Cannot open capture socket: interface is invalid");
         return;
     }
@@ -215,7 +215,7 @@ RawSocket::RawSocket(const Interface& interface)
     sockaddr_ll addr{};
     addr.sll_family = AF_PACKET;
     addr.sll_protocol = htons(ETH_P_ALL);
-    addr.sll_ifindex = static_cast<int>(interface_.Index());
+    addr.sll_ifindex = static_cast<int>(interface_->Index());
     if (bind(fd_.Get(), reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) != 0) {
         logger_.Error("Cannot bind AF_PACKET socket to interface: {}", Error::FromErrno());
         Close();
@@ -242,7 +242,7 @@ RawSocket::RawSocket(const Interface& interface)
 
     ifreq ifr{};
     // ifr is zero-initialized and Interface guarantees Name().size() < IFNAMSIZ.
-    std::memcpy(ifr.ifr_name, interface_.Name().data(), interface_.Name().size());
+    std::memcpy(ifr.ifr_name, interface_->Name().data(), interface_->Name().size());
     if (ioctl(fd_.Get(), BIOCSETIF, &ifr) != 0) {
         logger_.Error("Cannot bind BPF to interface: {}", Error::FromErrno());
         Close();
@@ -328,7 +328,7 @@ RawSocket::RawSocket(const Interface& interface)
 
 RawSocket::RawSocket(TestingTag, const Interface& interface, int owned_fd) noexcept
         : logger_{std::format("RawSocket:{}", interface.Name())}
-        , interface_{interface}
+        , interface_{&interface}
         , fd_{owned_fd} {
     // Production sizes receive_buffer_ during setup (constant on Linux, BIOCGBLEN on macOS);
     // tests skip that path, so use the same default the Linux production uses — enough for
@@ -368,7 +368,7 @@ bool RawSocket::SendUdpBroadcastDatagram(uint16_t dst_port, uint16_t src_port,
 bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t src_port,
         std::span<const std::byte> payload, uint8_t ttl) noexcept {
     const auto family = dst.addr.AddressFamily();
-    const auto source = interface_.SourceAddress(family);
+    const auto source = interface_->SourceAddress(family);
     if (!source) {
         logger_.Error("Cannot send to {}: interface has no source address for that family",
             dst.addr.ToString());
@@ -377,12 +377,12 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
 
     std::array<std::byte, SEND_BUFFER_SIZE> frame{};
 #if defined(__linux__)
-    const size_t length = BuildUdpFrame(dst_mac, interface_.Mac(), IpEndpoint{*source, src_port}, dst,
+    const size_t length = BuildUdpFrame(dst_mac, interface_->Mac(), IpEndpoint{*source, src_port}, dst,
         payload, ttl, frame);
 #else
     const size_t length = link_type_ == LinkType::Loopback
         ? BuildLoopbackUdpFrame(IpEndpoint{*source, src_port}, dst, payload, ttl, frame)
-        : BuildUdpFrame(dst_mac, interface_.Mac(), IpEndpoint{*source, src_port}, dst, payload, ttl, frame);
+        : BuildUdpFrame(dst_mac, interface_->Mac(), IpEndpoint{*source, src_port}, dst, payload, ttl, frame);
 #endif
     if (length == 0) {
         logger_.Error("Cannot build egress frame for {} ({}-byte payload)", dst.addr.ToString(),
@@ -395,7 +395,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
     // destination MAC already lives in the frame, so sll_addr/sll_halen stay zero.
     sockaddr_ll addr{};
     addr.sll_family = AF_PACKET;
-    addr.sll_ifindex = static_cast<int>(interface_.Index());
+    addr.sll_ifindex = static_cast<int>(interface_->Index());
     const auto sent = sendto(fd_.Get(), frame.data(), length, 0,
         reinterpret_cast<const sockaddr*>(&addr), sizeof(addr));
 #else
@@ -434,7 +434,7 @@ LinkSocket::MulticastMembership RawSocket::JoinMulticastGroup(const IpAddress& g
     // (default) interface. The group goes in as a sockaddr; ToSockaddr also sets the BSD sockaddr
     // length field that the kernel requires for the embedded address here.
     group_req request{};
-    request.gr_interface = interface_.Index();
+    request.gr_interface = interface_->Index();
     group.ToSockaddr(request.gr_group, /*port=*/0);
 
     const int level = v6 ? IPPROTO_IPV6 : IPPROTO_IP;
@@ -447,7 +447,7 @@ LinkSocket::MulticastMembership RawSocket::JoinMulticastGroup(const IpAddress& g
     }
 
     memberships.emplace(group, 1);
-    logger_.Debug("Joined multicast group {} (interface index {})", group.ToString(), interface_.Index());
+    logger_.Debug("Joined multicast group {} (interface index {})", group.ToString(), interface_->Index());
     return MakeMembership(group);
 }
 
@@ -473,7 +473,7 @@ bool RawSocket::Unregister(const IpAddress& group) noexcept {
     }
 
     group_req request{};
-    request.gr_interface = interface_.Index();
+    request.gr_interface = interface_->Index();
     group.ToSockaddr(request.gr_group, /*port=*/0);
     const int level = group.IsV6() ? IPPROTO_IPV6 : IPPROTO_IP;
     // Teardown-tolerant: when an interface loses its address the kernel drops the membership for

--- a/src/reflector/raw_socket.h
+++ b/src/reflector/raw_socket.h
@@ -57,7 +57,7 @@ public:
     [[nodiscard]] bool IsValid() const noexcept override { return fd_.IsValid(); }
     [[nodiscard]] int Fd() const noexcept override { return fd_.Get(); }
 
-    [[nodiscard]] const Interface& GetInterface() const noexcept override { return interface_; }
+    [[nodiscard]] const Interface& GetInterface() const noexcept override { return *interface_; }
 
     // Injects a UDP datagram out this interface as a raw L2 frame, building the Ethernet/IP/UDP
     // headers and checksums from the interface's cached source MAC/IP and writing the frame to the
@@ -125,7 +125,7 @@ private:
 #endif
 
     Logger logger_;
-    const Interface& interface_;
+    const Interface* interface_;
     UniqueFd fd_;
     // Per family: a dedicated unbound fd that holds that family's multicast memberships alive
     // (opened lazily on the first join, closed once the family has no joined group left), and the

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -26,9 +26,9 @@ SsdpReflector::SsdpReflector(PacketDispatcher& packet_dispatcher, LinkSocket& so
     LinkSocket& target_socket, const SsdpConfig& config)
         : DynamicFamilyReflector{LoggerName(config), source_socket.GetInterface(),
               target_socket.GetInterface(), FamilyCapability::PolicyOf(config)}
-        , source_socket_{source_socket}
-        , target_socket_{target_socket}
-        , packet_dispatcher_{packet_dispatcher}
+        , source_socket_{&source_socket}
+        , target_socket_{&target_socket}
+        , packet_dispatcher_{&packet_dispatcher}
         , config_mac_{config.mac}
         , eviction_timer_{packet_dispatcher.UnderlyingDispatcher()} {
     if (!ValidateConfig(config)) {
@@ -69,8 +69,8 @@ void SsdpReflector::Initialize(const SsdpConfig& config) {
     // is reflectable here, so the proxy always has a source_if V4 address to bind its listeners on. The
     // device speaks DIAL on target_if and the client reaches it on source_if (LOCATION rewrite direction).
     if (config.dial) {
-        dial_proxy_.emplace(packet_dispatcher_.UnderlyingDispatcher(), source_socket_.GetInterface(),
-            target_socket_.GetInterface(),
+        dial_proxy_.emplace(packet_dispatcher_->UnderlyingDispatcher(), source_socket_->GetInterface(),
+            target_socket_->GetInterface(),
             std::format("DialProxy:{}:{}->{}", config.name, config.source_if, config.target_if));
     }
 
@@ -107,15 +107,15 @@ bool SsdpReflector::SetUpGroup(const IpAddress& group, FamilySetup& setup) {
     // Program gate 2 so each interface actually receives the group's multicast. A failed join or
     // registration drops every token taken here when it leaves scope; setup is populated only on
     // full success.
-    auto source_membership = source_socket_.JoinMulticastGroup(group);
-    auto target_membership = target_socket_.JoinMulticastGroup(group);
+    auto source_membership = source_socket_->JoinMulticastGroup(group);
+    auto target_membership = target_socket_->JoinMulticastGroup(group);
     if (!source_membership.IsValid() || !target_membership.IsValid()) {
         logger_.Error("Cannot reflect ssdp {}: cannot join the group on both interfaces", group);
         return false;
     }
 
     // source -> target: reflect searches, unfiltered (any client on source may search).
-    auto source_registration = packet_dispatcher_.Register(source_socket_,
+    auto source_registration = packet_dispatcher_->Register(*source_socket_,
         PacketFilter{.dest_ip = group, .dest_port = SSDP_PORT},
         CreateDelegate<&SsdpReflector::OnSourcePacket>(this));
     if (!source_registration.IsValid()) {
@@ -124,7 +124,7 @@ bool SsdpReflector::SetUpGroup(const IpAddress& group, FamilySetup& setup) {
     }
 
     // target -> source: reflect advertisements, optionally only from the configured device's MAC.
-    auto target_registration = packet_dispatcher_.Register(target_socket_,
+    auto target_registration = packet_dispatcher_->Register(*target_socket_,
         PacketFilter{.dest_ip = group, .dest_port = SSDP_PORT, .source_mac = config_mac_},
         CreateDelegate<&SsdpReflector::OnTargetPacket>(this));
     if (!target_registration.IsValid()) {
@@ -170,7 +170,7 @@ void SsdpReflector::OnSourcePacket(const Packet& packet) noexcept {
 
     const uint16_t port = new_session ? new_session->reservation.Port()
                                                   : existing_session->reservation.Port();
-    if (!target_socket_.SendUdpMulticastDatagram(packet.header.dest, port,
+    if (!target_socket_->SendUdpMulticastDatagram(packet.header.dest, port,
             packet.payload, SSDP_TTL)) {
         logger_.Error("Cannot reflect M-SEARCH from {} to {}", packet.header.source, packet.header.dest);
         return;  // a new session's reservation + capture RAII-drop here
@@ -200,7 +200,7 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
             packet.header.source, sessions_.size());
         return std::nullopt;
     }
-    const auto& target_interface = target_socket_.GetInterface();
+    const auto& target_interface = target_socket_->GetInterface();
     const auto our_address = target_interface.SourceAddress(family);
     if (!our_address) {
         logger_.Error("Cannot reflect M-SEARCH from {}: target interface has no source address for {}",
@@ -212,7 +212,7 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
         return std::nullopt;  // Create logged the cause
     }
     // Register the 200-OK capture before the reflect, so a fast responder's reply can't arrive first.
-    auto capture = packet_dispatcher_.Register(target_socket_,
+    auto capture = packet_dispatcher_->Register(*target_socket_,
         PacketFilter{.dest_ip = our_address, .dest_port = reservation->Port(), .source_mac = config_mac_},
         CreateDelegate<&SsdpReflector::OnUnicastResponse>(this));
     if (!capture.IsValid()) {
@@ -241,7 +241,7 @@ void SsdpReflector::OnTargetPacket(const Packet& packet) noexcept {
     const auto payload = rewritten
         ? std::as_bytes(std::span<const char>{*rewritten})
         : packet.payload;
-    if (!source_socket_.SendUdpMulticastDatagram(packet.header.dest, SSDP_PORT, payload, SSDP_TTL)) {
+    if (!source_socket_->SendUdpMulticastDatagram(packet.header.dest, SSDP_PORT, payload, SSDP_TTL)) {
         logger_.Error("Cannot reflect ssdp packet from {} to {}", packet.header.source, packet.header.dest);
         return;
     }
@@ -270,7 +270,7 @@ void SsdpReflector::OnUnicastResponse(const Packet& packet) noexcept {
     const auto payload = rewritten
         ? std::as_bytes(std::span<const char>{*rewritten})
         : packet.payload;
-    if (!source_socket_.SendUdpDatagram(session.searcher_mac, session.searcher,
+    if (!source_socket_->SendUdpDatagram(session.searcher_mac, session.searcher,
             packet.header.source.port, payload, SSDP_TTL)) {
         logger_.Error("Cannot reflect SSDP response to searcher {}", session.searcher);
         return;

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -90,9 +90,9 @@ private:
     // passes it, so expiry is driven without reading the real clock.
     void EvictExpired(std::chrono::steady_clock::time_point now) noexcept;
 
-    LinkSocket& source_socket_;
-    LinkSocket& target_socket_;
-    PacketDispatcher& packet_dispatcher_;  // retained so OnSourcePacket can register response captures
+    LinkSocket* source_socket_;
+    LinkSocket* target_socket_;
+    PacketDispatcher* packet_dispatcher_;  // retained so OnSourcePacket can register response captures
     std::optional<MacAddress> config_mac_;  // device-scoping filter, reused on the response capture
     std::optional<DialProxy> dial_proxy_;  // the DIAL app proxy, engaged only when config.dial (IPv4-only)
     std::vector<Session> sessions_;

--- a/src/reflector/wol_reflector.cpp
+++ b/src/reflector/wol_reflector.cpp
@@ -21,7 +21,7 @@ std::string LoggerName(const WolConfig& config) {
 WolReflector::WolReflector(PacketDispatcher& packet_dispatcher, LinkSocket& source_socket,
     LinkSocket& target_socket, const WolConfig& config)
         : Reflector{LoggerName(config)}
-        , target_socket_{target_socket}
+        , target_socket_{&target_socket}
         , target_capability_{target_socket.GetInterface(), logger_, FamilyCapability::PolicyOf(config)} {
     if (!ValidateConfig(config)) {
         return;
@@ -39,7 +39,7 @@ bool WolReflector::ValidateConfig(const WolConfig& config) {
 }
 
 void WolReflector::Initialize(PacketDispatcher& packet_dispatcher, LinkSocket& source_socket, const WolConfig& config) {
-    const auto& target_interface = target_socket_.GetInterface();
+    const auto& target_interface = target_socket_->GetInterface();
     if (config.RequiresIPv4() && !target_interface.CanSend(IpAddress::Family::V4)) {
         logger_.Error("Cannot create wol reflector \"{}\": target_if \"{}\" cannot send IPv4",
             config.name, config.target_if);
@@ -156,9 +156,9 @@ void WolReflector::OnPacket(const Packet& packet) noexcept {
     const bool v4 = family == IpAddress::Family::V4;
     const auto destination = v4 ? IpAddress::BroadcastV4() : IpAddress::AllNodesLinkLocalV6();
     const bool sent = v4
-        ? target_socket_.SendUdpBroadcastDatagram(
+        ? target_socket_->SendUdpBroadcastDatagram(
               port, packet.header.source.port, packet.payload, packet.header.ttl)
-        : target_socket_.SendUdpMulticastDatagram(
+        : target_socket_->SendUdpMulticastDatagram(
               {destination, port}, packet.header.source.port, packet.payload, packet.header.ttl);
     if (!sent) {
         logger_.Error("Cannot reflect wol packet from {} to {}:{}",

--- a/src/reflector/wol_reflector.h
+++ b/src/reflector/wol_reflector.h
@@ -45,7 +45,7 @@ private:
     [[nodiscard]] bool HasRepeatedMac(std::span<const std::byte> payload) noexcept;
     void OnPacket(const Packet& packet) noexcept;
 
-    LinkSocket& target_socket_;
+    LinkSocket* target_socket_;
     // The target interface's per-family send capability, gated by the config's family policy.
     // Read live per packet, so an address change takes effect without re-creating the reflector
     // (a merely-used family is dropped quietly while the target can't send it); transition

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -72,9 +72,9 @@ HttpFraming::EndpointRewrite AsRewrite(Rewrite& rewrite) {
 // forwarding header then body — until Feed consumes nothing more, retaining the unconsumed tail. `out`
 // accumulates everything forwarded; `ok` goes false if Feed reports a malformed message.
 struct Driver {
-    explicit Driver(HttpFraming& f) : framing{f} {}
+    explicit Driver(HttpFraming& f) : framing{&f} {}
 
-    HttpFraming& framing;
+    HttpFraming* framing;
     std::string buffer;
     std::string out;
     bool ok = true;
@@ -86,7 +86,7 @@ struct Driver {
         buffer += chunk;
         std::string_view in{buffer};
         while (!in.empty()) {
-            const auto r = framing.Feed(in);
+            const auto r = framing->Feed(in);
             if (!r) {
                 ok = false;
                 return;


### PR DESCRIPTION
Replaces every reference data member with a raw pointer across the reflectors
(mDNS/SSDP/WoL), `DialProxy`, `RawSocket`, and the HTTP framing test helper.

## What changed
- Member declarations `T& m_;` → `T* m_;` — 14 members across 6 production classes + 1 test helper.
- Constructor *parameters* stay references; members initialize via `&param`, so call sites are unchanged.
- Member access becomes `m_->`; sites passing a member where a `T&` is expected deref with `*m_`.
- Three comments that named the reference type/`.`-access were updated to match.

## Why
These types are all `NoMove` (their dispatcher callbacks bind to `this`), so they were
never copyable/assignable — Core Guideline C.12's assignability rationale doesn't apply here.
The reference→pointer swap is semantically identical on these classes, so this is a
stylistic change with no behavioral effect.

## Verification (full data-path gate)
- docker Debug (ASan/UBSan): 801 tests, 0 failures
- docker Release: 801 tests, 0 failures
- e2e: 31 cases pass
- valgrind — unit (memcheck): 0 errors from 0 contexts
- valgrind — e2e (memcheck): 31 cases pass under valgrind
