### PR TITLE
feat: add debug_memory option to periodically log RSS and heap stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,11 @@ On RouterOS, setting the container's environment variables is usually easier tha
 
 ## Configuration
 
-`config.toml` contains optional top-level settings plus at least one reflector entry. An entry is a named table — its name is the label used in logs — describing one `source_if` → `target_if` bridge that enables any combination of the protocols. `log_level` is the only top-level setting:
+`config.toml` contains optional top-level settings plus at least one reflector entry. An entry is a named table — its name is the label used in logs — describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The top-level settings are `log_level` and `debug_memory`:
 
 ```toml
 log_level = "info"               # optional; one of debug | info | warning | error (default: info)
+debug_memory = false             # optional; periodically log RSS + heap arena stats for footprint debugging (default false)
 
 [tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
@@ -216,7 +217,7 @@ Every setting can also come from the environment, which is convenient for contai
 - `<TAG>` ties one entry's parameters together — any alphanumeric string (`1`, `2`, `TV`, …). It also becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MAC`, `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
-The only global is `REFLECTOR_LOG_LEVEL`, so `LOG` is a reserved tag. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The `[tv]` entry above looks like this in the environment:
+The globals are `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY`, so `LOG` and `DEBUG` are reserved tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The `[tv]` entry above looks like this in the environment:
 
 ```sh
 REFLECTOR_LOG_LEVEL=info
@@ -229,7 +230,7 @@ REFLECTOR_TV_SSDP=true
 REFLECTOR_TV_DIAL=true
 ```
 
-When a file and environment variables are both given they are merged: each contributes entries to one combined configuration, and `REFLECTOR_LOG_LEVEL` overrides the file's `log_level`. The [duplicate detection](#duplicate-detection) below applies across both sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all rejected at startup.
+When a file and environment variables are both given they are merged: each contributes entries to one combined configuration, and `REFLECTOR_LOG_LEVEL` / `REFLECTOR_DEBUG_MEMORY` override the file's `log_level` / `debug_memory`. The [duplicate detection](#duplicate-detection) below applies across both sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all rejected at startup.
 
 ### The `mac` field
 

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 # log_level = "info"  # debug | info | warning | error
+# debug_memory = false  # periodically log RSS + heap arena stats for footprint debugging
 
 # A single device: bridge its Wake-on-LAN, mDNS, and SSDP. The one mac is the device's NIC MAC —
 # the WoL magic-packet target and the L2 source of its mDNS/SSDP advertisements.

--- a/src/reflector/CMakeLists.txt
+++ b/src/reflector/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(reflector STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/ip_address.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mac_address.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mdns_message.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/memory_report.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/port_reservation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ssdp_message.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mdns_reflector.cpp

--- a/src/reflector/application.cpp
+++ b/src/reflector/application.cpp
@@ -5,6 +5,7 @@
 #include "event_loop_dispatcher.h"
 #include "logger.h"
 #include "mdns_reflector.h"
+#include "memory_report.h"
 #include "raw_socket.h"
 #include "ssdp_reflector.h"
 #include "util/delegate.h"
@@ -13,6 +14,7 @@
 
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <string_view>
@@ -27,6 +29,8 @@ Logger& GetLogger() noexcept {
     static Logger logger{"Application"};
     return logger;
 }
+// How often the memory diagnostic logs once debug_memory is enabled.
+constexpr std::chrono::seconds MEMORY_REPORT_INTERVAL{60};
 } // namespace
 
 namespace reflector {
@@ -121,6 +125,13 @@ bool Application::Configure(const Config& config) {
     if (ConfigureReflectors<WolReflector>(config.WolConfigs(), "wol")
         && ConfigureReflectors<MdnsReflector>(config.MdnsConfigs(), "mdns")
         && ConfigureReflectors<SsdpReflector>(config.SsdpConfigs(), "ssdp")) {
+        if (config.DebugMemory()) {
+            GetLogger().Info("Memory diagnostics enabled; reporting RSS/heap every {}s",
+                MEMORY_REPORT_INTERVAL.count());
+            LogMemoryReport();  // a baseline at startup, then every interval via the timer
+            memory_timer_.emplace(*dispatcher_);
+            memory_timer_->Start(MEMORY_REPORT_INTERVAL, CreateDelegate<&Application::ReportMemory>(this));
+        }
         return true;
     }
     // Fail closed: drop any reflectors wired before the failure so a config error never leaves a
@@ -186,6 +197,10 @@ void Application::OnWakeup(int fd) noexcept {
     std::array<std::byte, 64> scratch{};
     while (::read(fd, scratch.data(), scratch.size()) > 0) {
     }
+}
+
+void Application::ReportMemory(std::chrono::steady_clock::time_point) noexcept {
+    LogMemoryReport();
 }
 
 void Application::Run(const volatile std::sig_atomic_t& stop_requested) {

--- a/src/reflector/application.h
+++ b/src/reflector/application.h
@@ -7,13 +7,16 @@
 #include "interface.h"
 #include "link_socket.h"
 #include "reflector.h"
+#include "timer.h"
 #include "util/no_move.h"
 #include "util/unique_fd.h"
 
+#include <chrono>
 #include <csignal>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -103,6 +106,10 @@ private:
     // poll; the loop's stop_requested check ends the run. Level-triggered, so drain fully.
     void OnWakeup(int fd) noexcept;
 
+    // The periodic callback of memory_timer_ (debug_memory only): logs RSS and, on glibc, the heap
+    // arena breakdown. The timer's fire-time argument is unused.
+    void ReportMemory(std::chrono::steady_clock::time_point) noexcept;
+
     InterfaceFactory interface_factory_;
     SocketFactory socket_factory_;
 
@@ -120,6 +127,11 @@ private:
     DefaultPacketDispatcher packet_dispatcher_{*dispatcher_};
     std::vector<std::unique_ptr<Reflector>> reflectors_;
     std::unique_ptr<AddressMonitor> address_monitor_;
+
+    // Periodic RSS/heap-stats logger, engaged only when config.DebugMemory() is set (a deployment
+    // footprint diagnostic). Holds a timer registration bound to `this` on dispatcher_, so it must
+    // tear down before dispatcher_ — it does, being declared after it.
+    std::optional<Timer> memory_timer_;
 
     // Signal-wakeup self-pipe (best-effort; populated by PrepareSignalWakeup, otherwise empty). Declared
     // last so it tears down first: wakeup_reg_ unregisters from dispatcher_ while it is still alive, then

--- a/src/reflector/config/config.cpp
+++ b/src/reflector/config/config.cpp
@@ -190,15 +190,23 @@ private:
 
 using EnvParams = std::map<std::string, std::string, std::less<>>;
 
-// Environment values are strings, so a boolean must be spelled out. true/false mirror TOML; 1/0 are
-// accepted too since they are the natural booleans for shell/Docker env files.
-std::expected<bool, Error> ParseEnvBool(std::string_view name, std::string_view key, std::string_view value) {
+// true/1 -> true, false/0 -> false (case-insensitive); nullopt otherwise. The shared core of every
+// env boolean — env values are strings, so booleans are spelled out (true/false mirror TOML), with
+// 1/0 accepted as the natural shell/Docker booleans. Callers wrap it with a context-specific error.
+std::optional<bool> ParseBool(std::string_view value) {
     const auto lower = AsciiToLower(value);
     if (lower == "true" || lower == "1") {
         return true;
     }
     if (lower == "false" || lower == "0") {
         return false;
+    }
+    return std::nullopt;
+}
+
+std::expected<bool, Error> ParseEnvBool(std::string_view name, std::string_view key, std::string_view value) {
+    if (const auto parsed = ParseBool(value)) {
+        return *parsed;
     }
     return std::unexpected(Error{"entry \"{}\" {} must be true/false or 1/0; got \"{}\"", name, key, value});
 }
@@ -383,6 +391,7 @@ struct ConfigAccumulator {
     std::vector<MdnsConfig> mdns;
     std::vector<SsdpConfig> ssdp;
     std::optional<LogLevel> log_level;
+    std::optional<bool> debug_memory;
     std::vector<std::string> entry_names;
 
     std::optional<Error> AddEntry(const ConfigSource& source) {
@@ -424,8 +433,14 @@ std::optional<Error> ApplyToml(ConfigAccumulator& acc, std::string_view str) {
                 return std::move(level).error();
             }
             acc.log_level = *level;
+        } else if (key_name == "debug_memory") {
+            const auto field_value = value.value<bool>();
+            if (!field_value) {
+                return Error{"debug_memory must be a boolean"};
+            }
+            acc.debug_memory = *field_value;
         } else {
-            return Error{"unexpected top-level key: \"{}\" (expected an entry table or log_level)", key_name};
+            return Error{"unexpected top-level key: \"{}\" (expected an entry table, log_level, or debug_memory)", key_name};
         }
     }
     return std::nullopt;
@@ -442,8 +457,10 @@ bool IsAlnumTag(std::string_view tag) noexcept {
 std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> env_vars) {
     constexpr std::string_view prefix = "REFLECTOR_";
     constexpr std::string_view log_level_var = "REFLECTOR_LOG_LEVEL";
+    constexpr std::string_view debug_memory_var = "REFLECTOR_DEBUG_MEMORY";
 
     std::optional<std::string_view> log_level_value;
+    std::optional<std::string_view> debug_memory_value;
     // tag -> (lowercase param -> value). std::map gives a deterministic (sorted) entry order so that
     // duplicate-detection errors and tests don't depend on environ ordering.
     std::map<std::string, EnvParams, std::less<>> tags;
@@ -454,6 +471,10 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
         }
         if (var.key == log_level_var) {
             log_level_value = var.value;
+            continue;
+        }
+        if (var.key == debug_memory_var) {
+            debug_memory_value = var.value;
             continue;
         }
         const auto rest = var.key.substr(prefix.size());
@@ -469,6 +490,9 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
         if (AsciiToLower(tag) == "log") {
             return Error{"environment variable \"{}\": \"{}\" is a reserved tag (use REFLECTOR_LOG_LEVEL for the log level)", var.key, tag};
         }
+        if (AsciiToLower(tag) == "debug") {
+            return Error{"environment variable \"{}\": \"{}\" is a reserved tag (use REFLECTOR_DEBUG_MEMORY for the memory diagnostic)", var.key, tag};
+        }
         if (param.empty()) {
             return Error{"environment variable \"{}\" is missing a parameter name after the tag", var.key};
         }
@@ -481,6 +505,14 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
             return std::move(level).error();
         }
         acc.log_level = *level;
+    }
+
+    if (debug_memory_value) {
+        const auto parsed = ParseBool(*debug_memory_value);
+        if (!parsed) {
+            return Error{"REFLECTOR_DEBUG_MEMORY must be true/false or 1/0; got \"{}\"", *debug_memory_value};
+        }
+        acc.debug_memory = *parsed;
     }
 
     for (auto& [tag, params] : tags) {
@@ -545,6 +577,7 @@ std::expected<Config, Error> Config::Load(std::optional<std::string_view> toml_t
     config.mdns_configs_ = std::move(acc.mdns);
     config.ssdp_configs_ = std::move(acc.ssdp);
     config.log_level_ = acc.log_level.value_or(LogLevel::Info);
+    config.debug_memory_ = acc.debug_memory.value_or(false);
     if (config.ReflectorCount() == 0) {
         return std::unexpected(Error{"configuration must contain at least one reflector"});
     }

--- a/src/reflector/config/config.h
+++ b/src/reflector/config/config.h
@@ -39,6 +39,9 @@ public:
     [[nodiscard]] const std::vector<MdnsConfig>& MdnsConfigs() const noexcept { return mdns_configs_; }
     [[nodiscard]] const std::vector<SsdpConfig>& SsdpConfigs() const noexcept { return ssdp_configs_; }
     [[nodiscard]] LogLevel MinLogLevel() const noexcept { return log_level_; }
+    // When set, the application periodically logs its RSS and (on glibc) heap arena stats — a
+    // deployment diagnostic for tracking footprint where no shell is available. Off by default.
+    [[nodiscard]] bool DebugMemory() const noexcept { return debug_memory_; }
 
 private:
     // Test-only: builds a Config programmatically, bypassing TOML parsing.
@@ -53,6 +56,7 @@ private:
     std::vector<MdnsConfig> mdns_configs_;
     std::vector<SsdpConfig> ssdp_configs_;
     LogLevel log_level_ = LogLevel::Info;
+    bool debug_memory_ = false;
 };
 
 } // namespace reflector
@@ -73,7 +77,7 @@ struct std::formatter<reflector::Config, char>
     template <typename FmtContext>
     FmtContext::iterator format(const reflector::Config& c, FmtContext& ctx) const
     {
-        std::format_to(ctx.out(), "{{log_level: {}, wol: [", c.MinLogLevel());
+        std::format_to(ctx.out(), "{{log_level: {}, debug_memory: {}, wol: [", c.MinLogLevel(), c.DebugMemory());
         bool first = true;
         for (const auto& wol_config : c.WolConfigs()) {
             if (first) {

--- a/src/reflector/memory_report.cpp
+++ b/src/reflector/memory_report.cpp
@@ -1,0 +1,78 @@
+#include "memory_report.h"
+
+#include "logger.h"
+#include "platform.h"
+
+#include <cstddef>
+#include <cstdio>
+
+#include <sys/resource.h>
+#include <unistd.h>
+
+#if defined(__GLIBC__)
+#include <malloc.h>  // mallinfo2
+#if __GLIBC_PREREQ(2, 33)
+#define REFLECTOR_HAVE_MALLINFO2 1
+#endif
+#endif
+
+namespace reflector {
+
+namespace {
+
+Logger& GetLogger() noexcept {
+    static Logger logger{"MemoryReport"};
+    return logger;
+}
+
+// Peak resident set size in KiB via getrusage (portable). ru_maxrss is KiB on Linux/FreeBSD but
+// bytes on macOS; normalize to KiB. 0 if the call fails.
+size_t PeakRssKib() noexcept {
+    rusage usage{};
+    if (getrusage(RUSAGE_SELF, &usage) != 0) {
+        return 0;
+    }
+#if defined(__APPLE__)
+    return static_cast<size_t>(usage.ru_maxrss) / 1024;  // bytes -> KiB
+#else
+    return static_cast<size_t>(usage.ru_maxrss);         // already KiB
+#endif
+}
+
+#if defined(__linux__)
+// Current RSS in KiB from /proc/self/statm (field 2 = resident pages). 0 if unavailable.
+size_t CurrentRssKib() noexcept {
+    std::FILE* file = std::fopen("/proc/self/statm", "re");
+    if (file == nullptr) {
+        return 0;
+    }
+    unsigned long total_pages = 0;
+    unsigned long resident_pages = 0;
+    const int matched = std::fscanf(file, "%lu %lu", &total_pages, &resident_pages);
+    std::fclose(file);
+    if (matched != 2) {
+        return 0;
+    }
+    const long page_size = sysconf(_SC_PAGESIZE);
+    return static_cast<size_t>(resident_pages) * static_cast<size_t>(page_size) / 1024;
+}
+#endif
+
+} // namespace
+
+void LogMemoryReport() {
+#if defined(REFLECTOR_HAVE_MALLINFO2)
+    const auto info = mallinfo2();
+    GetLogger().Info(
+        "rss={} KiB, peak={} KiB; heap in_use={} KiB, free_retained={} KiB, arena={} KiB, mmap={} KiB",
+        CurrentRssKib(), PeakRssKib(),
+        info.uordblks / 1024, info.fordblks / 1024, info.arena / 1024, info.hblkhd / 1024);
+#elif defined(__linux__)
+    GetLogger().Info("rss={} KiB, peak={} KiB (heap arena stats need glibc >= 2.33)",
+        CurrentRssKib(), PeakRssKib());
+#else
+    GetLogger().Info("peak={} KiB (detailed heap stats are glibc/Linux-only)", PeakRssKib());
+#endif
+}
+
+} // namespace reflector

--- a/src/reflector/memory_report.h
+++ b/src/reflector/memory_report.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace reflector {
+
+// Logs the process's memory footprint at Info level (under its own "MemoryReport" logger): current
+// RSS, peak RSS, and — on glibc — the heap arena breakdown (bytes in use vs free-but-retained vs
+// total arena vs mmap'd). The glibc breakdown is the diagnostic that reveals allocator retention: a
+// small in-use figure under a large arena means freed memory the allocator is holding rather than
+// returning to the OS. A deployment aid for tracking footprint where no shell is available; the
+// caller gates it on Config::DebugMemory.
+void LogMemoryReport();
+
+} // namespace reflector

--- a/tests/application_test.cpp
+++ b/tests/application_test.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <cerrno>
+#include <chrono>
 #include <csignal>
 #include <cstdint>
 #include <memory>
@@ -174,6 +175,32 @@ TEST_F(ApplicationTest, SharesOneSocketPerInterfaceAcrossConfigs) {
     // The shared source fd is watched exactly once, however many reflectors register on it.
     EXPECT_EQ(dispatcher_->RegistrationCount(), 1);
     EXPECT_TRUE(dispatcher_->IsWatching(Socket("src")->fd));
+}
+
+TEST_F(ApplicationTest, StartsMemoryReportTimerWhenDebugMemoryEnabled) {
+    auto app = MakeApp();
+    const Config config = TestConfigBuilder{}
+        .Add(MakeWolConfig("tv", "src", "dst", {7}))
+        .DebugMemory(true)
+        .Build();
+
+    ASSERT_TRUE(app.Configure(config));
+
+    // A WoL-only config starts no timers of its own, so the periodic memory report is the only one.
+    EXPECT_EQ(dispatcher_->TimerCount(), 1u);
+    // Firing it exercises the ReportMemory callback (reads /proc + mallinfo2 on glibc); must not crash.
+    dispatcher_->FireTimers(std::chrono::steady_clock::now());
+}
+
+TEST_F(ApplicationTest, NoMemoryReportTimerByDefault) {
+    auto app = MakeApp();
+    const Config config = TestConfigBuilder{}
+        .Add(MakeWolConfig("tv", "src", "dst", {7}))
+        .Build();
+
+    ASSERT_TRUE(app.Configure(config));
+
+    EXPECT_EQ(dispatcher_->TimerCount(), 0u);
 }
 
 TEST_F(ApplicationTest, CreatesDistinctSocketsForDistinctInterfaces) {

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -2026,4 +2026,110 @@ wol = true
     EXPECT_EQ(config->MinLogLevel(), LogLevel::Debug);
 }
 
+// --- debug_memory ---
+
+TEST(ConfigTest, DebugMemoryDefaultsToFalse) {
+    const auto config = Config::FromString(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)");
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_FALSE(config->DebugMemory());
+}
+
+TEST(ConfigTest, ParsesDebugMemoryTrue) {
+    const auto config = Config::FromString(R"(
+debug_memory = true
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)");
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_TRUE(config->DebugMemory());
+}
+
+TEST(ConfigTest, ParsesDebugMemoryFalse) {
+    const auto config = Config::FromString(R"(
+debug_memory = false
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)");
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_FALSE(config->DebugMemory());
+}
+
+TEST(ConfigTest, RejectsNonBoolDebugMemory) {
+    EXPECT_FALSE(Config::FromString(R"(
+debug_memory = "yes"
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)").has_value());
+}
+
+TEST(ConfigTest, EnvSetsDebugMemory) {
+    for (const auto* value : {"true", "1"}) {
+        const auto config = Config::Load(std::nullopt, Env({
+            {"REFLECTOR_DEBUG_MEMORY", value},
+            {"REFLECTOR_1_SOURCE_IF", "eth0"},
+            {"REFLECTOR_1_TARGET_IF", "eth1"},
+            {"REFLECTOR_1_WOL", "true"},
+        }));
+        ASSERT_TRUE(config.has_value()) << config.error().Message();
+        EXPECT_TRUE(config->DebugMemory());
+    }
+}
+
+TEST(ConfigTest, EnvDisablesDebugMemory) {
+    for (const auto* value : {"false", "0"}) {
+        const auto config = Config::Load(std::nullopt, Env({
+            {"REFLECTOR_DEBUG_MEMORY", value},
+            {"REFLECTOR_1_SOURCE_IF", "eth0"},
+            {"REFLECTOR_1_TARGET_IF", "eth1"},
+            {"REFLECTOR_1_WOL", "true"},
+        }));
+        ASSERT_TRUE(config.has_value()) << config.error().Message();
+        EXPECT_FALSE(config->DebugMemory());
+    }
+}
+
+TEST(ConfigTest, EnvRejectsInvalidDebugMemory) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_DEBUG_MEMORY", "maybe"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvRejectsReservedDebugTag) {
+    // A REFLECTOR_DEBUG_<x> other than the special-cased MEMORY must not be read as an entry "debug".
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_DEBUG_VERBOSE", "true"},
+        {"REFLECTOR_1_SOURCE_IF", "eth0"},
+        {"REFLECTOR_1_TARGET_IF", "eth1"},
+        {"REFLECTOR_1_WOL", "true"},
+    }));
+    EXPECT_FALSE(config.has_value());
+}
+
+TEST(ConfigTest, EnvDebugMemoryOverridesFile) {
+    const auto config = Config::Load(R"(
+debug_memory = false
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({{"REFLECTOR_DEBUG_MEMORY", "true"}}));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_TRUE(config->DebugMemory());
+}
+
 }  // namespace reflector

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -59,6 +59,11 @@ public:
         return *this;
     }
 
+    TestConfigBuilder& DebugMemory(bool enabled) {
+        config_.debug_memory_ = enabled;
+        return *this;
+    }
+
     [[nodiscard]] Config Build() const { return config_; }
 
 private:


### PR DESCRIPTION
Adds an opt-in **`debug_memory`** diagnostic that periodically logs the process's memory footprint — a deployment aid for tracking RSS where there's no shell access (e.g. MikroTik RouterOS containers).

## What it does
When enabled, the application logs (under a `MemoryReport` logger) a baseline at startup and then every 60 s:
- **glibc/Linux:** current RSS (`/proc/self/statm`), peak RSS (`getrusage`), and the `mallinfo2` heap arena breakdown — `in_use` / `free_retained` / `arena` / `mmap`. `in_use` ≪ `arena` is the signal that the allocator is holding freed memory rather than returning it to the OS.
- **macOS/FreeBSD:** peak RSS only (heap breakdown is glibc-only).

## Config (runtime, mirrors `log_level`)
- TOML top-level `debug_memory = true|false`, or env `REFLECTOR_DEBUG_MEMORY=true|1`.
- Off by default; the `debug` env tag is reserved (like `log`) so `REFLECTOR_DEBUG_*` can't be misread as a reflector entry.
- Runtime, not compile-time — toggle it on a deployed binary without rebuilding.

## Notes
- Zero overhead when off (no timer constructed).
- `ParseBool` extracted so env boolean parsing is shared with `ParseEnvBool`.
- Documented in the README and sample `config.toml`.

## Tests
- Config tests (TOML/env parse, default-off, reserved `debug` tag, env-overrides-file).
- Application test that the report timer starts only when enabled and fires the report callback.
- Green: 820/820 local (ASan/UBSan) and 812/812 docker Debian glibc (ASan/UBSan, exercising the `mallinfo2` path).
