### PR TITLE
feat: report cgroup memory stats and read RSS from /proc/self/status

### DIFF
--- a/src/reflector/memory_report.cpp
+++ b/src/reflector/memory_report.cpp
@@ -2,15 +2,16 @@
 
 #include "logger.h"
 #include "platform.h"
+#include "util/narrow_cast.h"
 
 #include <cstddef>
 #include <cstdio>
-
+#include <cstring>
+#include <optional>
 #include <sys/resource.h>
-#include <unistd.h>
 
 #if defined(__GLIBC__)
-#include <malloc.h>  // mallinfo2
+#include <malloc.h>  // mallinfo2 (glibc-only header)
 #if __GLIBC_PREREQ(2, 33)
 #define REFLECTOR_HAVE_MALLINFO2 1
 #endif
@@ -25,53 +26,167 @@ Logger& GetLogger() noexcept {
     return logger;
 }
 
-// Peak resident set size in KiB via getrusage (portable). ru_maxrss is KiB on Linux/FreeBSD but
-// bytes on macOS; normalize to KiB. 0 if the call fails.
-size_t PeakRssKib() noexcept {
-    rusage usage{};
-    if (getrusage(RUSAGE_SELF, &usage) != 0) {
-        return 0;
+#if defined(__linux__)
+
+// A "<key>: <N> kB" value from /proc/self/status, in KiB; nullopt if absent/unreadable. VmRSS is the
+// current resident set, VmHWM its peak (high-water) — the same kernel counters ps/getrusage report,
+// read here from one file so current and peak are consistent.
+std::optional<size_t> StatusValueKib(const char* key) noexcept {
+    std::FILE* file = std::fopen("/proc/self/status", "r");
+    if (file == nullptr) {
+        return std::nullopt;
     }
-#if defined(__APPLE__)
-    return static_cast<size_t>(usage.ru_maxrss) / 1024;  // bytes -> KiB
-#else
-    return static_cast<size_t>(usage.ru_maxrss);         // already KiB
-#endif
+    const size_t key_len = std::strlen(key);
+    char line[256];
+    std::optional<size_t> value;
+    while (std::fgets(line, sizeof(line), file) != nullptr) {
+        if (std::strncmp(line, key, key_len) == 0 && line[key_len] == ':') {
+            unsigned long kib = 0;
+            if (std::sscanf(line + key_len + 1, " %lu kB", &kib) == 1) {
+                value = narrow_cast<size_t>(kib);
+            }
+            break;
+        }
+    }
+    std::fclose(file);
+    return value;
 }
 
-#if defined(__linux__)
-// Current RSS in KiB from /proc/self/statm (field 2 = resident pages). 0 if unavailable.
-size_t CurrentRssKib() noexcept {
-    std::FILE* file = std::fopen("/proc/self/statm", "re");
+// A single unsigned integer (bytes) from a one-value cgroup file (memory.current / memory.peak).
+std::optional<size_t> ReadByteCount(const char* path) noexcept {
+    std::FILE* file = std::fopen(path, "r");
     if (file == nullptr) {
-        return 0;
+        return std::nullopt;
     }
-    unsigned long total_pages = 0;
-    unsigned long resident_pages = 0;
-    const int matched = std::fscanf(file, "%lu %lu", &total_pages, &resident_pages);
+    unsigned long long bytes = 0;
+    const int matched = std::fscanf(file, "%llu", &bytes);
     std::fclose(file);
-    if (matched != 2) {
-        return 0;
-    }
-    const long page_size = sysconf(_SC_PAGESIZE);
-    return static_cast<size_t>(resident_pages) * static_cast<size_t>(page_size) / 1024;
+    return matched == 1 ? std::optional<size_t>{narrow_cast<size_t>(bytes)} : std::nullopt;
 }
-#endif
+
+// The container's cgroup v2 memory accounting — the figure RouterOS (and the OOM killer) sees: process
+// RSS plus page cache plus kernel/socket memory. Absent if this isn't cgroup v2 or /sys/fs/cgroup is
+// not mounted in the container.
+struct CgroupMemory {
+    bool available = false;
+    size_t current = 0;          // bytes
+    std::optional<size_t> peak;  // bytes; memory.peak needs kernel >= 5.19
+    size_t anon = 0;             // bytes — heap/stack (~ process anon RSS)
+    size_t file = 0;             // bytes — page cache
+    size_t sock = 0;             // bytes — socket buffers
+    size_t slab = 0;             // bytes — kernel slab (reclaimable + unreclaimable)
+};
+
+// Fills `out` with the process's own cgroup v2 directory under /sys/fs/cgroup, derived from
+// /proc/self/cgroup ("0::<path>"). Inside a container the path is the namespaced root "/" (so the mount
+// root); on a bare host it's the service/session sub-cgroup. false if not cgroup v2 / unreadable.
+bool CgroupDir(char* out, size_t out_size) noexcept {
+    std::FILE* file = std::fopen("/proc/self/cgroup", "r");
+    if (file == nullptr) {
+        return false;
+    }
+    char line[512];
+    bool found = false;
+    while (std::fgets(line, sizeof(line), file) != nullptr) {
+        if (std::strncmp(line, "0::", 3) == 0) {  // the cgroup v2 unified-hierarchy entry
+            char* path = line + 3;
+            path[std::strcspn(path, "\n")] = '\0';  // drop the trailing newline
+            // The namespaced root is "/", which maps to the mount root; otherwise append the sub-path.
+            std::snprintf(out, out_size, "/sys/fs/cgroup%s", std::strcmp(path, "/") == 0 ? "" : path);
+            found = true;
+            break;
+        }
+    }
+    std::fclose(file);
+    return found;
+}
+
+CgroupMemory ReadCgroupMemory() noexcept {
+    CgroupMemory mem;
+    char dir[640];  // "/sys/fs/cgroup" + the <=508-char path from /proc/self/cgroup, with headroom
+    if (!CgroupDir(dir, sizeof(dir))) {
+        return mem;  // not cgroup v2, or /proc/self/cgroup unreadable
+    }
+    char path[700];
+    std::snprintf(path, sizeof(path), "%s/memory.current", dir);
+    const auto current = ReadByteCount(path);
+    if (!current) {
+        return mem;  // memory controller not enabled for this cgroup (e.g. the root cgroup)
+    }
+    mem.available = true;
+    mem.current = *current;
+    std::snprintf(path, sizeof(path), "%s/memory.peak", dir);
+    mem.peak = ReadByteCount(path);
+
+    std::snprintf(path, sizeof(path), "%s/memory.stat", dir);
+    std::FILE* file = std::fopen(path, "r");
+    if (file != nullptr) {
+        size_t slab_reclaimable = 0;
+        size_t slab_unreclaimable = 0;
+        char key[64];
+        unsigned long long value = 0;
+        while (std::fscanf(file, "%63s %llu", key, &value) == 2) {
+            if (std::strcmp(key, "anon") == 0) {
+                mem.anon = narrow_cast<size_t>(value);
+            } else if (std::strcmp(key, "file") == 0) {
+                mem.file = narrow_cast<size_t>(value);
+            } else if (std::strcmp(key, "sock") == 0) {
+                mem.sock = narrow_cast<size_t>(value);
+            } else if (std::strcmp(key, "slab_reclaimable") == 0) {
+                slab_reclaimable = narrow_cast<size_t>(value);
+            } else if (std::strcmp(key, "slab_unreclaimable") == 0) {
+                slab_unreclaimable = narrow_cast<size_t>(value);
+            }
+        }
+        mem.slab = slab_reclaimable + slab_unreclaimable;
+        std::fclose(file);
+    }
+    return mem;
+}
+
+void LogCgroupMemory() {
+    const auto cg = ReadCgroupMemory();
+    if (!cg.available) {
+        GetLogger().Info("cgroup memory unavailable (not cgroup v2, or /sys/fs/cgroup not mounted)");
+        return;
+    }
+    const auto kib = [](size_t bytes) { return bytes / 1024; };
+    if (cg.peak) {
+        GetLogger().Info("cgroup current={} KiB, peak={} KiB; anon={} KiB, file={} KiB, sock={} KiB, slab={} KiB",
+            kib(cg.current), kib(*cg.peak), kib(cg.anon), kib(cg.file), kib(cg.sock), kib(cg.slab));
+    } else {
+        GetLogger().Info("cgroup current={} KiB; anon={} KiB, file={} KiB, sock={} KiB, slab={} KiB",
+            kib(cg.current), kib(cg.anon), kib(cg.file), kib(cg.sock), kib(cg.slab));
+    }
+}
+
+#endif  // __linux__
 
 } // namespace
 
 void LogMemoryReport() {
+#if defined(__linux__)
+    const size_t rss = StatusValueKib("VmRSS").value_or(0);
+    const size_t peak = StatusValueKib("VmHWM").value_or(0);
 #if defined(REFLECTOR_HAVE_MALLINFO2)
     const auto info = mallinfo2();
     GetLogger().Info(
         "rss={} KiB, peak={} KiB; heap in_use={} KiB, free_retained={} KiB, arena={} KiB, mmap={} KiB",
-        CurrentRssKib(), PeakRssKib(),
-        info.uordblks / 1024, info.fordblks / 1024, info.arena / 1024, info.hblkhd / 1024);
-#elif defined(__linux__)
-    GetLogger().Info("rss={} KiB, peak={} KiB (heap arena stats need glibc >= 2.33)",
-        CurrentRssKib(), PeakRssKib());
+        rss, peak, info.uordblks / 1024, info.fordblks / 1024, info.arena / 1024, info.hblkhd / 1024);
 #else
-    GetLogger().Info("peak={} KiB (detailed heap stats are glibc/Linux-only)", PeakRssKib());
+    GetLogger().Info("rss={} KiB, peak={} KiB (heap arena stats need glibc >= 2.33)", rss, peak);
+#endif
+    LogCgroupMemory();
+#else
+    // Non-Linux (macOS/FreeBSD): no /proc or cgroup; report peak RSS via getrusage.
+    rusage usage{};
+    const size_t peak = getrusage(RUSAGE_SELF, &usage) != 0 ? 0
+#if defined(__APPLE__)
+        : static_cast<size_t>(usage.ru_maxrss) / 1024;  // bytes -> KiB
+#else
+        : static_cast<size_t>(usage.ru_maxrss);         // already KiB
+#endif
+    GetLogger().Info("peak={} KiB (detailed RSS/heap/cgroup stats are glibc/Linux-only)", peak);
 #endif
 }
 


### PR DESCRIPTION
Improves the `debug_memory` diagnostic (#19) so it reports the memory that actually explains the container footprint.

## Changes
- **Process line:** current/peak RSS now come from `/proc/self/status` (`VmRSS`/`VmHWM`). Replaces `/proc/self/statm` (which returned a bogus resident value on RouterOS) and getrusage's peak (redundant with current for a monotonic process). Heap `mallinfo2` breakdown unchanged.
- **New cgroup line (separate, to keep lines short):** the container's cgroup v2 accounting — `memory.current`, `memory.peak`, and the `memory.stat` breakdown (`anon`/`file`/`sock`/`slab`). Resolved via `/proc/self/cgroup`, so it works both inside a container (RouterOS) and as a bare process (systemd service / shell session); falls back to "unavailable" on cgroup v1 or the root cgroup.

## Why
RouterOS's memory gauge is the **cgroup** charge — process RSS plus page cache plus kernel/socket memory — which the process RSS and heap stats can't see. The heap is tiny and stable (~265 KiB); the footprint growth lives in the cgroup (page cache / kernel slab / socket buffers), which this surfaces and itemizes.

## Validation
- Build + 820 unit tests (ASan/UBSan).
- e2e in the cgroup-v2 container, two-line output confirmed, e.g.:
  `cgroup current=1500 KiB, peak=5736 KiB; anon=104 KiB, file=4 KiB, sock=0 KiB, slab=459 KiB`
  (peak ≫ current — the footprint is volatile/reclaimable, not a heap leak).
