### PR TITLE
feat!: nest reflector entries under a [reflectors] map (0.7.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(reflector VERSION 0.6.6 LANGUAGES CXX)
+project(reflector VERSION 0.7.0 LANGUAGES CXX)
 include(CTest)
 
 if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Logs are timestamped in UTC by default; pass `-e TZ=Europe/Berlin` (any zoneinfo
 The `arm64`, `arm/v7`, and `arm/v5` variants let the reflector run on the router itself through the RouterOS *Container* feature, bridging two of the router's VLANs without a separate host. Since it has to see both segments, give the container **two `veth` interfaces, one bridged into each VLAN**, and name them as the entry's `source_if` / `target_if`:
 
 ```toml
-[livingroom-tv]
+[reflectors.livingroom-tv]
 source_if = "veth-lan"   # veth bridged into the LAN VLAN
 target_if = "veth-iot"   # veth bridged into the IoT VLAN
 mac       = "B0:37:95:C5:60:BE"   # optional; target a specific device (omit for the whole VLAN)
@@ -190,13 +190,13 @@ On RouterOS, setting the container's environment variables is usually easier tha
 
 ## Configuration
 
-`config.toml` contains optional top-level settings plus at least one reflector entry. An entry is a named table — its name is the label used in logs — describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The top-level settings are `log_level` and `debug_memory`:
+`config.toml` contains optional top-level settings plus at least one reflector entry. Entries are tables under `reflectors`, keyed by name (`[reflectors.<name>]`) — the name is the label used in logs — each describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The top-level settings are `log_level` and `debug_memory`:
 
 ```toml
 log_level = "info"               # optional; one of debug | info | warning | error (default: info)
 debug_memory = false             # optional; periodically log RSS + heap arena stats for footprint debugging (default false)
 
-[tv]
+[reflectors.tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
 target_if = "lo0"                # required; interface to emit reflected traffic on
 mac       = "B0:37:95:C5:60:BE"  # optional; the device's MAC (see below). Omit for a whole network.
@@ -217,7 +217,7 @@ Every setting can also come from the environment, which is convenient for contai
 - `<TAG>` ties one entry's parameters together — any alphanumeric string (`1`, `2`, `TV`, …). It also becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MAC`, `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
-The globals are `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY`, so `LOG` and `DEBUG` are reserved tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The `[tv]` entry above looks like this in the environment:
+The globals are `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY`, so `LOG` and `DEBUG` are reserved tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The `[reflectors.tv]` entry above looks like this in the environment:
 
 ```sh
 REFLECTOR_LOG_LEVEL=info

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@
 
 # A single device: bridge its Wake-on-LAN, mDNS, and SSDP. The one mac is the device's NIC MAC —
 # the WoL magic-packet target and the L2 source of its mDNS/SSDP advertisements.
-[tv]
+[reflectors.tv]
 source_if = "en0"
 target_if = "lo0"
 mac = "B0:37:95:C5:60:BE"  # optional; omit to bridge the whole network
@@ -14,7 +14,7 @@ ssdp = true
 
 # A whole network (no mac): reflect all mDNS/SSDP discovery in both directions, on its own
 # interface pair (entries sharing source_if + target_if and a protocol would collide).
-[guest-discovery]
+[reflectors.guest-discovery]
 source_if = "en1"
 target_if = "en2"
 mdns = true

--- a/e2e/config-addrchange.toml
+++ b/e2e/config-addrchange.toml
@@ -4,7 +4,7 @@ log_level = "debug"
 # v4 and v6 independently. The address-change cases knock out one (interface, family) at a time and prove
 # via real traffic that only that family's reflection stops, then resumes once the address returns.
 
-[wol]
+[reflectors.wol]
 source_if = "wol_src"
 target_if = "wol_dst"
 mac = "02:42:ac:11:00:09"
@@ -12,7 +12,7 @@ wol = true
 wol_ports = [40009]
 address_family = "dual"
 
-[discovery]
+[reflectors.discovery]
 source_if = "wol_src"
 target_if = "wol_dst"
 mdns = true

--- a/e2e/config-dial.toml
+++ b/e2e/config-dial.toml
@@ -1,8 +1,8 @@
 log_level = "debug"
 
 # A single DIAL entry, so the reflector's SSDP relay carries the device's 200 OK exactly once (the shared
-# config.toml's any-MAC [discovery] entry would otherwise double-reflect it). DIAL requires ssdp.
-[dial-tv]
+# config.toml's any-MAC [reflectors.discovery] entry would otherwise double-reflect it). DIAL requires ssdp.
+[reflectors.dial-tv]
 source_if = "wol_src"
 target_if = "wol_dst"
 ssdp = true

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -1,19 +1,19 @@
 log_level = "debug"
 
-[wol-mac]
+[reflectors.wol-mac]
 source_if = "wol_src"
 target_if = "wol_dst"
 mac = "02:42:ac:11:00:09"
 wol = true
 wol_ports = [40009]
 
-[wol-any]
+[reflectors.wol-any]
 source_if = "wol_src"
 target_if = "wol_dst"
 wol = true
 wol_ports = [40011]
 
-[discovery]
+[reflectors.discovery]
 source_if = "wol_src"
 target_if = "wol_dst"
 mdns = true

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -841,8 +841,8 @@ class DockerDial(DockerE2E):
         super().__init__(args, shim)
         self.dial = case
         # The DIAL reflector loads a config with a single DIAL entry. The shared config's any-MAC
-        # [discovery] entry also reflects SSDP, which would double-reflect the device's 200 OK (only one
-        # copy rewritten) -- so the DIAL case gets its own config to keep the relayed reply unambiguous.
+        # [reflectors.discovery] entry also reflects SSDP, which would double-reflect the device's 200 OK
+        # (only one copy rewritten) -- so the DIAL case gets its own config to keep the relayed reply unambiguous.
         self.config_path = E2E_DIR / "config-dial.toml"
         self.device_container = f"{self.prefix}-device"
         self.client_container = f"{self.prefix}-client"

--- a/src/reflector/config/config.cpp
+++ b/src/reflector/config/config.cpp
@@ -416,12 +416,24 @@ std::optional<Error> ApplyToml(ConfigAccumulator& acc, std::string_view str) {
     const auto root_table = std::move(parsed).table();
     for (const auto& [key, value] : root_table) {
         const auto key_name = ToStringView(key);
-        // A top-level table is a reflector entry (its key is the entry name); the lone known scalar
-        // is log_level; any other top-level scalar is a mistyped setting.
-        if (const auto* entry_table = value.as_table()) {
-            const TomlSource source{key_name, *entry_table};
-            if (auto error = acc.AddEntry(source)) {
-                return error;
+        // Reflector entries live under the `reflectors` map ([reflectors.<name>]); log_level and
+        // debug_memory are the top-level scalars. A top-level table other than `reflectors` (a bare
+        // [tv]) is a pre-0.7 entry and is rejected by the final branch.
+        if (key_name == "reflectors") {
+            const auto* reflectors_table = value.as_table();
+            if (!reflectors_table) {
+                return Error{"reflectors must be a table of [reflectors.<name>] entries"};
+            }
+            for (const auto& [entry_key, entry_value] : *reflectors_table) {
+                const auto entry_name = ToStringView(entry_key);
+                const auto* entry_table = entry_value.as_table();
+                if (!entry_table) {
+                    return Error{"reflector \"{}\" must be a table ([reflectors.{}])", entry_name, entry_name};
+                }
+                const TomlSource source{entry_name, *entry_table};
+                if (auto error = acc.AddEntry(source)) {
+                    return error;
+                }
             }
         } else if (key_name == "log_level") {
             const auto field_value = value.value<std::string_view>();
@@ -440,7 +452,7 @@ std::optional<Error> ApplyToml(ConfigAccumulator& acc, std::string_view str) {
             }
             acc.debug_memory = *field_value;
         } else {
-            return Error{"unexpected top-level key: \"{}\" (expected an entry table, log_level, or debug_memory)", key_name};
+            return Error{"unexpected top-level key: \"{}\" (expected reflectors, log_level, or debug_memory)", key_name};
         }
     }
     return std::nullopt;

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -33,7 +33,7 @@ std::string TomlWithLogLevel(std::string_view log_level) {
     toml += log_level;
     toml += R"("
 
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -141,7 +141,7 @@ TEST(ConfigTest, VerifyRejectsEmptyPorts) {
 
 TEST(ConfigTest, ParsesSingleProtocolEntry) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -164,13 +164,13 @@ wol = true
 
 TEST(ConfigTest, ParsesMultipleEntries) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:00:00:00:00:0a"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:00:00:00:00:0b"
 source_if = "eth2"
 target_if = "eth3"
@@ -187,7 +187,7 @@ wol = true
 
 TEST(ConfigTest, ParsesExplicitWolPorts) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -199,7 +199,7 @@ wol_ports = [7, 9, 4000]
 
 TEST(ConfigTest, ParsesAddressFamily) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -211,7 +211,7 @@ address_family = "ipv6"
 
 TEST(ConfigTest, ExpandsAllThreeProtocolsFromOneEntry) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -230,7 +230,7 @@ ssdp = true
 
 TEST(ConfigTest, ExpandsWolAndMdns) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 wol = true
@@ -244,7 +244,7 @@ mdns = true
 
 TEST(ConfigTest, ExpandsWolAndSsdp) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 wol = true
@@ -258,7 +258,7 @@ ssdp = true
 
 TEST(ConfigTest, ExpandsMdnsAndSsdp) {
     const auto config = Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -272,7 +272,7 @@ ssdp = true
 
 TEST(ConfigTest, SharedFieldsPropagateToEachEnabledProtocol) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -310,7 +310,7 @@ address_family = "dual"
 
 TEST(ConfigTest, NetworkEntryHasNoMac) {
     const auto config = Config::FromString(R"(
-[net]
+[reflectors.net]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -323,7 +323,7 @@ ssdp = true
 
 TEST(ConfigTest, AcceptsMissingMac) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -336,7 +336,7 @@ wol = true
 
 TEST(ConfigTest, LogLevelDefaultsToInfo) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -379,7 +379,7 @@ TEST(ConfigTest, ParsesLogLevelAlongsideEntries) {
     const auto config = Config::FromString(R"(
 log_level = "debug"
 
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 wol = true
@@ -397,7 +397,7 @@ TEST(ConfigTest, RejectsNonStringLogLevel) {
     EXPECT_FALSE(Config::FromString(R"(
 log_level = 5
 
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -438,7 +438,7 @@ TEST(ConfigTest, ReadsAndParsesFileConfig) {
         std::ofstream file{path};
         ASSERT_TRUE(file);
         file << R"(
-[file]
+[reflectors.file]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -475,7 +475,7 @@ TEST(ConfigTest, RejectsUnknownTopLevelScalar) {
     EXPECT_FALSE(Config::FromString(R"(
 log_levle = "debug"
 
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -486,7 +486,7 @@ wol = true
 
 TEST(ConfigTest, RejectsEntryEnablingNoProtocol) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 )").has_value());
@@ -494,7 +494,7 @@ target_if = "eth1"
 
 TEST(ConfigTest, RejectsWolPortsWithoutWol) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 mdns = true
@@ -504,7 +504,7 @@ wol_ports = [7, 9]
 
 TEST(ConfigTest, RejectsNonBooleanProtocolFlag) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = "yes"
@@ -513,7 +513,7 @@ wol = "yes"
 
 TEST(ConfigTest, RejectsMissingSourceIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 target_if = "eth1"
 wol = true
 )").has_value());
@@ -521,7 +521,7 @@ wol = true
 
 TEST(ConfigTest, RejectsMissingTargetIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 wol = true
 )").has_value());
@@ -529,7 +529,7 @@ wol = true
 
 TEST(ConfigTest, RejectsSameInterfaces) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth0"
 wol = true
@@ -539,7 +539,7 @@ wol = true
 TEST(ConfigTest, RejectsEmptyName) {
     // The entry name is the table key; an empty key fails the per-protocol Verify (name required).
     EXPECT_FALSE(Config::FromString(R"(
-[""]
+[reflectors.""]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -549,7 +549,7 @@ wol = true
 TEST(ConfigTest, RejectsEmptyNameMdns) {
     // Same invariant via MdnsConfig::Verify (empty name reaches a different protocol's check).
     EXPECT_FALSE(Config::FromString(R"(
-[""]
+[reflectors.""]
 source_if = "eth0"
 target_if = "eth1"
 mdns = true
@@ -559,7 +559,7 @@ mdns = true
 TEST(ConfigTest, RejectsEmptyNameSsdp) {
     // Same invariant via SsdpConfig::Verify.
     EXPECT_FALSE(Config::FromString(R"(
-[""]
+[reflectors.""]
 source_if = "eth0"
 target_if = "eth1"
 ssdp = true
@@ -568,7 +568,7 @@ ssdp = true
 
 TEST(ConfigTest, RejectsUnknownEntryField) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -578,7 +578,7 @@ extra = "x"
 
 TEST(ConfigTest, RejectsNonStringField) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = 123
 target_if = "eth1"
 wol = true
@@ -589,7 +589,7 @@ wol = true
 
 TEST(ConfigTest, RejectsInvalidMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "not-a-mac"
 source_if = "eth0"
 target_if = "eth1"
@@ -599,7 +599,7 @@ wol = true
 
 TEST(ConfigTest, RejectsTooShortMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "00:11:22:33:44"
 source_if = "eth0"
 target_if = "eth1"
@@ -609,7 +609,7 @@ wol = true
 
 TEST(ConfigTest, RejectsNonHexMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "GG:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -619,7 +619,7 @@ wol = true
 
 TEST(ConfigTest, RejectsDashSeparatedMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "00-11-22-33-44-55"
 source_if = "eth0"
 target_if = "eth1"
@@ -629,7 +629,7 @@ wol = true
 
 TEST(ConfigTest, RejectsEmptyMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = ""
 source_if = "eth0"
 target_if = "eth1"
@@ -639,7 +639,7 @@ wol = true
 
 TEST(ConfigTest, AcceptsUppercaseMac) {
     EXPECT_TRUE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "B0:37:95:C5:60:BE"
 source_if = "en0"
 target_if = "lo0"
@@ -649,7 +649,7 @@ wol = true
 
 TEST(ConfigTest, AcceptsLowercaseMac) {
     EXPECT_TRUE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = "b0:37:95:c5:60:be"
 source_if = "en0"
 target_if = "lo0"
@@ -661,7 +661,7 @@ wol = true
 
 TEST(ConfigTest, RejectsUnknownAddressFamily) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -671,7 +671,7 @@ address_family = "ipx"
 
 TEST(ConfigTest, RejectsNonStringAddressFamily) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -683,7 +683,7 @@ address_family = 4
 
 TEST(ConfigTest, RejectsEmptyPortsArray) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -693,7 +693,7 @@ wol_ports = []
 
 TEST(ConfigTest, RejectsNonArrayPorts) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -703,7 +703,7 @@ wol_ports = "7"
 
 TEST(ConfigTest, RejectsNonIntegerPort) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -713,7 +713,7 @@ wol_ports = ["7"]
 
 TEST(ConfigTest, RejectsPortZeroFromToml) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -723,7 +723,7 @@ wol_ports = [0]
 
 TEST(ConfigTest, RejectsDuplicatePorts) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -733,7 +733,7 @@ wol_ports = [7, 9, 7]
 
 TEST(ConfigTest, RejectsOutOfRangePort) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -747,12 +747,12 @@ TEST(ConfigTest, RejectsDuplicateEntryName) {
     // TOML itself rejects two tables with the same name, which is why the parser needs no name
     // dedup of its own (see the comment on AppendWol).
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[tv]
+[reflectors.tv]
 source_if = "eth2"
 target_if = "eth3"
 wol = true
@@ -761,13 +761,13 @@ wol = true
 
 TEST(ConfigTest, RejectsDuplicateMacSourceTargetTriple) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -777,12 +777,12 @@ wol = true
 
 TEST(ConfigTest, RejectsDuplicateUnfilteredSourceTargetRule) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -791,12 +791,12 @@ wol = true
 
 TEST(ConfigTest, RejectsSpecificRuleOverlappedByUnfilteredRule) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -806,13 +806,13 @@ wol = true
 
 TEST(ConfigTest, AcceptsSameMacWithDifferentTargets) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth2"
@@ -824,13 +824,13 @@ wol = true
 
 TEST(ConfigTest, AcceptsOverlappingMacSelectionWithDisjointPorts) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 wol_ports = [7]
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -843,12 +843,12 @@ wol_ports = [9]
 
 TEST(ConfigTest, AcceptsOverlappingMacSelectionWithDifferentSources) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth2"
 target_if = "eth1"
@@ -860,12 +860,12 @@ wol = true
 
 TEST(ConfigTest, AcceptsOverlappingMacSelectionWithDifferentTargets) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth2"
@@ -879,14 +879,14 @@ wol = true
 // is not a duplicate — it is just the long form of one "dual" rule.
 TEST(ConfigTest, AcceptsIdenticalRuleWithDisjointAddressFamilies) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 address_family = "ipv4"
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -900,14 +900,14 @@ address_family = "ipv6"
 // "default" handles IPv4 too, so it overlaps an ipv4-only rule on the same triple.
 TEST(ConfigTest, RejectsOverlappingRuleWhenDefaultCoversIpv4) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 address_family = "default"
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
@@ -920,13 +920,13 @@ TEST(ConfigTest, RejectsDuplicateIpv6OnlyRules) {
     // Two ipv6-only rules on the same triple collide via the IPv6 disjunct of AddressFamiliesOverlap
     // (the IPv4 disjunct is false for both) -- the mirror of the default/ipv4 case above.
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 address_family = "ipv6"
 
-[b]
+[reflectors.b]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -938,12 +938,12 @@ address_family = "ipv6"
 
 TEST(ConfigTest, RejectsDuplicateMdnsRuleAcrossEntries) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -952,12 +952,12 @@ mdns = true
 
 TEST(ConfigTest, RejectsDuplicateSsdpRuleAcrossEntries) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -968,12 +968,12 @@ TEST(ConfigTest, AcceptsOverlappingDifferentProtocolsAcrossEntries) {
     // Same source/target, but one entry does WoL and the other mDNS — different protocol vectors,
     // so no dedup collision.
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 wol = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -985,12 +985,12 @@ mdns = true
 
 TEST(ConfigTest, AcceptsDisjointEntries) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "guest"
 ssdp = true
@@ -1003,7 +1003,7 @@ ssdp = true
 
 TEST(ConfigTest, ExpandsMdnsOnly) {
     const auto config = Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -1022,7 +1022,7 @@ mdns = true
 
 TEST(ConfigTest, ExpandsSsdpOnly) {
     const auto config = Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1043,7 +1043,7 @@ ssdp = true
 
 TEST(ConfigTest, ExplicitFalseFlagDoesNotEnable) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = false
@@ -1056,7 +1056,7 @@ mdns = true
 
 TEST(ConfigTest, AllExplicitFalseRejected) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = false
@@ -1069,7 +1069,7 @@ ssdp = false
 
 TEST(ConfigTest, WolPortsFullyReplaceDefaults) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1081,7 +1081,7 @@ wol_ports = [40000]
 
 TEST(ConfigTest, AcceptsMaxPort) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1093,7 +1093,7 @@ wol_ports = [65535]
 
 TEST(ConfigTest, RejectsNegativePort) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1103,9 +1103,20 @@ wol_ports = [-1]
 
 // --- top-level key classification ---
 
-TEST(ConfigTest, LogLevelAsTableIsEntryNotScalar) {
-    // A [log_level] table is classified as an entry (table wins over the scalar name), so it is sent
-    // to ReadEntry and rejected for enabling no protocol — not parsed as the log_level setting.
+TEST(ConfigTest, RejectsTopLevelEntryTable) {
+    // The pre-0.7 form: a bare [tv] table at the top level. Entries now live only under
+    // [reflectors.<name>], so a top-level table other than `reflectors` is an unexpected key.
+    EXPECT_FALSE(Config::FromString(R"(
+[tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)").has_value());
+}
+
+TEST(ConfigTest, RejectsLogLevelAsTable) {
+    // log_level is a top-level scalar; a [log_level] table is rejected (must be a string), not read
+    // as a reflector entry.
     EXPECT_FALSE(Config::FromString(R"(
 [log_level]
 source_if = "eth0"
@@ -1113,11 +1124,26 @@ target_if = "eth1"
 )").has_value());
 }
 
+TEST(ConfigTest, RejectsReflectorsScalar) {
+    // `reflectors` must be a table of entries, not a scalar.
+    EXPECT_FALSE(Config::FromString(R"(
+reflectors = "oops"
+)").has_value());
+}
+
+TEST(ConfigTest, RejectsNonTableReflectorEntry) {
+    // A non-table value inside the reflectors map (here a scalar) is not a valid entry.
+    EXPECT_FALSE(Config::FromString(R"(
+[reflectors]
+tv = "oops"
+)").has_value());
+}
+
 // --- non-string field types ---
 
 TEST(ConfigTest, RejectsNonStringMac) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 mac = 123
 source_if = "eth0"
 target_if = "eth1"
@@ -1127,7 +1153,7 @@ wol = true
 
 TEST(ConfigTest, RejectsNonStringTargetIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = 123
 wol = true
@@ -1138,7 +1164,7 @@ wol = true
 
 TEST(ConfigTest, ParsesAddressFamilyIpv4) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1153,7 +1179,7 @@ address_family = "ipv4"
 
 TEST(ConfigTest, RejectsMdnsMissingSourceIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 target_if = "iot"
 mdns = true
 )").has_value());
@@ -1161,7 +1187,7 @@ mdns = true
 
 TEST(ConfigTest, RejectsMdnsMissingTargetIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 mdns = true
 )").has_value());
@@ -1169,7 +1195,7 @@ mdns = true
 
 TEST(ConfigTest, RejectsMdnsSameInterfaces) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 target_if = "lan"
 mdns = true
@@ -1178,7 +1204,7 @@ mdns = true
 
 TEST(ConfigTest, RejectsSsdpMissingSourceIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 target_if = "iot"
 ssdp = true
 )").has_value());
@@ -1186,7 +1212,7 @@ ssdp = true
 
 TEST(ConfigTest, RejectsSsdpMissingTargetIf) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 ssdp = true
 )").has_value());
@@ -1194,7 +1220,7 @@ ssdp = true
 
 TEST(ConfigTest, RejectsSsdpSameInterfaces) {
     EXPECT_FALSE(Config::FromString(R"(
-[disc]
+[reflectors.disc]
 source_if = "lan"
 target_if = "lan"
 ssdp = true
@@ -1207,13 +1233,13 @@ TEST(ConfigTest, AcceptsDistinctConcreteMacsSameTriple) {
     // Two different concrete MACs on the same source/target/ports do not collide: MacSelectionsOverlap
     // is false only when both are set and unequal.
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:66"
 source_if = "eth0"
 target_if = "eth1"
@@ -1227,13 +1253,13 @@ TEST(ConfigTest, RejectsPartialPortOverlap) {
     // Sharing a single port (9) is enough to collide — PortsOverlap is any-shared-element, not set
     // equality.
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
 wol_ports = [7, 9]
 
-[b]
+[reflectors.b]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1245,13 +1271,13 @@ wol_ports = [9, 40000]
 
 TEST(ConfigTest, RejectsMdnsDuplicateMacTriple) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -1261,12 +1287,12 @@ mdns = true
 
 TEST(ConfigTest, RejectsMdnsSpecificOverlappedByUnfiltered) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -1276,13 +1302,13 @@ mdns = true
 
 TEST(ConfigTest, AcceptsMdnsDistinctMacs) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:66"
 source_if = "lan"
 target_if = "iot"
@@ -1294,12 +1320,12 @@ mdns = true
 
 TEST(ConfigTest, AcceptsMdnsDifferentSources) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 source_if = "lan2"
 target_if = "iot"
 mdns = true
@@ -1310,12 +1336,12 @@ mdns = true
 
 TEST(ConfigTest, AcceptsMdnsDifferentTargets) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot2"
 mdns = true
@@ -1326,13 +1352,13 @@ mdns = true
 
 TEST(ConfigTest, AcceptsMdnsDisjointAddressFamilies) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 address_family = "ipv4"
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -1344,13 +1370,13 @@ address_family = "ipv6"
 
 TEST(ConfigTest, RejectsMdnsDefaultOverlapsIpv4) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 mdns = true
 address_family = "default"
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 mdns = true
@@ -1362,13 +1388,13 @@ address_family = "ipv4"
 
 TEST(ConfigTest, RejectsSsdpDuplicateMacTriple) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -1378,12 +1404,12 @@ ssdp = true
 
 TEST(ConfigTest, RejectsSsdpSpecificOverlappedByUnfiltered) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
@@ -1393,13 +1419,13 @@ ssdp = true
 
 TEST(ConfigTest, AcceptsSsdpDistinctMacs) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 mac = "00:11:22:33:44:55"
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 mac = "00:11:22:33:44:66"
 source_if = "lan"
 target_if = "iot"
@@ -1411,12 +1437,12 @@ ssdp = true
 
 TEST(ConfigTest, AcceptsSsdpDifferentSources) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 source_if = "lan2"
 target_if = "iot"
 ssdp = true
@@ -1427,12 +1453,12 @@ ssdp = true
 
 TEST(ConfigTest, AcceptsSsdpDifferentTargets) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot2"
 ssdp = true
@@ -1443,13 +1469,13 @@ ssdp = true
 
 TEST(ConfigTest, AcceptsSsdpDisjointAddressFamilies) {
     const auto config = Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 address_family = "ipv4"
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1461,13 +1487,13 @@ address_family = "ipv6"
 
 TEST(ConfigTest, RejectsSsdpDefaultOverlapsIpv4) {
     EXPECT_FALSE(Config::FromString(R"(
-[a]
+[reflectors.a]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
 address_family = "default"
 
-[b]
+[reflectors.b]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1573,7 +1599,7 @@ TEST(ConfigTest, SsdpFormatterPrintsMacAndDialFalse) {
 TEST(ConfigTest, ConfigFormatterRendersAllSections) {
     const auto config = Config::FromString(R"(
 log_level = "warning"
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 wol = true
@@ -1590,7 +1616,7 @@ ssdp = true
 
 TEST(ConfigTest, ParsesSsdpDialFlagFromToml) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1603,7 +1629,7 @@ dial = true
 
 TEST(ConfigTest, SsdpDialDefaultsFalse) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1618,7 +1644,7 @@ TEST(ConfigTest, RejectsDialWithoutSsdp) {
     // dial-without-ssdp branch; asserting on "dial" ensures the dial-specific error fired (the
     // no-protocol message also contains "ssdp", so a "ssdp" assertion would pass via the wrong path).
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 wol = true
@@ -1630,7 +1656,7 @@ dial = true
 
 TEST(ConfigTest, RejectsNonBooleanDial) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1644,7 +1670,7 @@ TEST(ConfigTest, RejectsDialWithIpv6OnlyFamilyFromToml) {
     // The IPv4-only rejection (struct-level Verify is tested separately) also fires through the parser:
     // AppendSsdp runs Verify before appending, so a dial+ipv6 entry is rejected, not stored.
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "lan"
 target_if = "iot"
 ssdp = true
@@ -1945,7 +1971,7 @@ TEST(ConfigTest, EnvRejectsEmptyConfiguration) {
 
 TEST(ConfigTest, MergeCombinesFileAndEnvEntries) {
     const auto config = Config::Load(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1963,7 +1989,7 @@ wol = true
 
 TEST(ConfigTest, MergeDetectsCrossSourceDuplicate) {
     const auto config = Config::Load(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1977,7 +2003,7 @@ wol = true
 
 TEST(ConfigTest, MergeDetectsDuplicateNameAcrossSources) {
     const auto config = Config::Load(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -1993,7 +2019,7 @@ wol = true
 TEST(ConfigTest, EnvLogLevelOverridesFile) {
     const auto config = Config::Load(R"(
 log_level = "error"
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2005,7 +2031,7 @@ wol = true
 TEST(ConfigTest, FileLogLevelKeptWhenEnvUnset) {
     const auto config = Config::Load(R"(
 log_level = "warning"
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2017,7 +2043,7 @@ wol = true
 TEST(ConfigTest, EnvLogLevelSetsWhenFileOmitsIt) {
     // File contributes an entry but no log_level; the env supplies it (sole setter, not an override).
     const auto config = Config::Load(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2030,7 +2056,7 @@ wol = true
 
 TEST(ConfigTest, DebugMemoryDefaultsToFalse) {
     const auto config = Config::FromString(R"(
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2042,7 +2068,7 @@ wol = true
 TEST(ConfigTest, ParsesDebugMemoryTrue) {
     const auto config = Config::FromString(R"(
 debug_memory = true
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2054,7 +2080,7 @@ wol = true
 TEST(ConfigTest, ParsesDebugMemoryFalse) {
     const auto config = Config::FromString(R"(
 debug_memory = false
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2066,7 +2092,7 @@ wol = true
 TEST(ConfigTest, RejectsNonBoolDebugMemory) {
     EXPECT_FALSE(Config::FromString(R"(
 debug_memory = "yes"
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true
@@ -2123,7 +2149,7 @@ TEST(ConfigTest, EnvRejectsReservedDebugTag) {
 TEST(ConfigTest, EnvDebugMemoryOverridesFile) {
     const auto config = Config::Load(R"(
 debug_memory = false
-[tv]
+[reflectors.tv]
 source_if = "eth0"
 target_if = "eth1"
 wol = true

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -745,7 +745,7 @@ wol_ports = [65536]
 
 TEST(ConfigTest, RejectsDuplicateEntryName) {
     // TOML itself rejects two tables with the same name, which is why the parser needs no name
-    // dedup of its own (see the comment on AppendWol).
+    // dedup of its own (see the comment on AppendConfig).
     EXPECT_FALSE(Config::FromString(R"(
 [reflectors.tv]
 source_if = "eth0"
@@ -1174,7 +1174,7 @@ address_family = "ipv4"
     EXPECT_EQ(config->WolConfigs().front().address_family, AddressFamily::IPv4);
 }
 
-// --- per-protocol Verify reached through the parser (AppendMdns / AppendSsdp call their own
+// --- per-protocol Verify reached through the parser (AppendConfig runs each protocol's own
 //     MdnsConfig::Verify / SsdpConfig::Verify, independent of WoL) ---
 
 TEST(ConfigTest, RejectsMdnsMissingSourceIf) {
@@ -1267,7 +1267,7 @@ wol_ports = [9, 40000]
 )").has_value());
 }
 
-// --- mDNS dedup matrix (AppendMdns is independent of AppendWol) ---
+// --- mDNS dedup matrix (AppendConfig dedups mdns_configs independently of WoL) ---
 
 TEST(ConfigTest, RejectsMdnsDuplicateMacTriple) {
     EXPECT_FALSE(Config::FromString(R"(
@@ -1384,7 +1384,7 @@ address_family = "ipv4"
 )").has_value());
 }
 
-// --- SSDP dedup matrix (AppendSsdp is independent of AppendWol / AppendMdns) ---
+// --- SSDP dedup matrix (AppendConfig dedups ssdp_configs independently of WoL / mDNS) ---
 
 TEST(ConfigTest, RejectsSsdpDuplicateMacTriple) {
     EXPECT_FALSE(Config::FromString(R"(
@@ -1668,7 +1668,7 @@ dial = "yes"
 
 TEST(ConfigTest, RejectsDialWithIpv6OnlyFamilyFromToml) {
     // The IPv4-only rejection (struct-level Verify is tested separately) also fires through the parser:
-    // AppendSsdp runs Verify before appending, so a dial+ipv6 entry is rejected, not stored.
+    // AppendConfig runs Verify before appending, so a dial+ipv6 entry is rejected, not stored.
     const auto config = Config::FromString(R"(
 [reflectors.tv]
 source_if = "lan"


### PR DESCRIPTION
## What

TOML config entries move from top-level tables (`[tv]`) to a `reflectors` map (`[reflectors.tv]`), aligning the schema with the sibling `ruflector` rewrite.

- Reflector entries now live only under `[reflectors.<name>]`.
- `log_level` and `debug_memory` stay as top-level scalars.
- A top-level table other than `reflectors` (e.g. a bare `[tv]`) is now **rejected** at startup.
- The `REFLECTOR_<tag>_<param>` environment path is **unchanged** — only the file format nests.

## Breaking change

Existing config files must move each `[entry]` under `[reflectors.entry]`:

```toml
# before              # after
[tv]                  [reflectors.tv]
source_if = "en0"     source_if = "en0"
```

Version bumped 0.6.6 → 0.7.0.

## Changes

- `src/reflector/config/config.cpp` — parser dispatches on the `reflectors` map; added guards for a non-table `reflectors` and non-table entries, with an updated "unexpected top-level key" message.
- `config.toml`, `e2e/config*.toml` — entries re-nested under `reflectors`.
- `README.md` — config example, prose, MikroTik example, and env-section reference.
- `tests/config_test.cpp` — TOML literals re-nested; replaced the obsolete top-level-classification test with `RejectsTopLevelEntryTable`, `RejectsLogLevelAsTable`, `RejectsReflectorsScalar`, and `RejectsNonTableReflectorEntry`.
- `e2e/run.py` — comment reference updated.

## Testing

Full gate green:

- native unit 811/811
- docker debug 803/803, docker release 803/803
- docker valgrind (unit) 803 — no leaks, 0 memcheck errors
- e2e 31/31, e2e under valgrind 31/31
