### PR TITLE
Rely on SA_RESTART instead of looping on EINTR in the data path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 #include <csignal>
+#include <signal.h>
 #include <exception>
 #include <optional>
 #include <string>
@@ -64,6 +65,19 @@ void SignalHandler(int) {
     }
 }
 
+// Registers SignalHandler for SIGINT/SIGTERM with SA_RESTART, so the kernel auto-restarts a
+// send/recv/read/write interrupted by one of them: the data path never observes EINTR and so never
+// loops on it. Only epoll_wait/kevent (never restarted regardless of SA_RESTART) still surface EINTR,
+// handled in EventLoopDispatcher::PollOnce. sigaction, not std::signal, because signal()'s restart
+// semantics are platform- and feature-macro-dependent (System V vs BSD); we want SA_RESTART guaranteed.
+void InstallSignalHandler(int signal_number) {
+    struct sigaction action{};
+    action.sa_handler = SignalHandler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+    sigaction(signal_number, &action, nullptr);
+}
+
 void ConfigureStdoutBuffering() noexcept {
     if (!isatty(fileno(stdout))) {
         // Docker and service managers capture stdout through a pipe; line buffering keeps log lines visible before shutdown.
@@ -73,8 +87,8 @@ void ConfigureStdoutBuffering() noexcept {
 
 int Run(int argc, char* argv[]) {
     ConfigureStdoutBuffering();
-    std::signal(SIGINT, SignalHandler);
-    std::signal(SIGTERM, SignalHandler);
+    InstallSignalHandler(SIGINT);
+    InstallSignalHandler(SIGTERM);
 
     reflector::Logger logger("main");
     if (argc > 2) {

--- a/src/reflector/application.h
+++ b/src/reflector/application.h
@@ -57,8 +57,9 @@ public:
 
     // Sets up a self-pipe and registers its read end with the dispatcher, returning the write fd a signal
     // handler writes one byte to in order to break the blocking poll immediately -- the loop then re-checks
-    // stop_requested and exits, instead of waiting up to one poll interval. Also robust to a SA_RESTART
-    // handler (signal()'s default on Linux) that would otherwise restart the poll rather than surface EINTR.
+    // stop_requested and exits, instead of waiting up to one poll interval. The byte -- not the poll
+    // returning EINTR -- is what breaks the wait, so shutdown stays prompt even on a platform whose
+    // blocking poll restarts after a signal instead of surfacing EINTR.
     // Best-effort: returns -1 (after logging a warning) if the pipe or its registration cannot be set up,
     // leaving shutdown bounded by the poll interval. Call once, after Configure, before Run. Production
     // wiring only -- the other tests never call it, so their dispatcher-registration counts are unperturbed.

--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -141,9 +141,6 @@ void DefaultAddressMonitor::OnReadable(int /*fd*/) noexcept {
     while (true) {
         const auto received = recv(fd_.Get(), buffer.data(), buffer.size(), 0);
         if (received < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
             if (IsWouldBlockErrno(errno)) {
                 break;  // drained
             }

--- a/src/reflector/interface_address.cpp
+++ b/src/reflector/interface_address.cpp
@@ -140,9 +140,6 @@ bool NetlinkDump(int fd, uint16_t request_type, uint32_t seq, Handler&& handle) 
     while (true) {
         const auto needed = recv(fd, buffer.data(), buffer.size(), MSG_PEEK | MSG_TRUNC);
         if (needed < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
             GetLogger().Error("Cannot read netlink dump reply: {}", Error::FromErrno());
             return false;
         }
@@ -152,9 +149,6 @@ bool NetlinkDump(int fd, uint16_t request_type, uint32_t seq, Handler&& handle) 
 
         const auto received = recv(fd, buffer.data(), buffer.size(), 0);
         if (received < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
             GetLogger().Error("Cannot read netlink dump reply: {}", Error::FromErrno());
             return false;
         }

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -528,10 +528,7 @@ std::optional<Packet> RawSocket::Receive() noexcept {
 #if defined(__linux__)
     // MSG_TRUNC makes recv report the frame's real length even when it exceeds the buffer, so a
     // frame that didn't fit is detectable (bytes > buffer) instead of being silently truncated.
-    ssize_t bytes;
-    do {
-        bytes = recv(fd_.Get(), receive_buffer_.data(), receive_buffer_.size(), MSG_TRUNC);
-    } while (bytes < 0 && errno == EINTR);
+    const ssize_t bytes = recv(fd_.Get(), receive_buffer_.data(), receive_buffer_.size(), MSG_TRUNC);
     if (bytes < 0) {
         if (IsWouldBlockErrno(errno)) {
             return std::nullopt;
@@ -548,10 +545,7 @@ std::optional<Packet> RawSocket::Receive() noexcept {
 
 #else
     if (receive_buffer_offset_ >= receive_buffer_filled_) {
-        ssize_t bytes;
-        do {
-            bytes = read(fd_.Get(), receive_buffer_.data(), receive_buffer_.size());
-        } while (bytes < 0 && errno == EINTR);
+        const ssize_t bytes = read(fd_.Get(), receive_buffer_.data(), receive_buffer_.size());
         if (bytes < 0) {
             if (IsWouldBlockErrno(errno)) {
                 return std::nullopt;


### PR DESCRIPTION
## Summary

Register `SIGINT`/`SIGTERM` with `SA_RESTART` so the kernel auto-restarts data-path syscalls interrupted by a signal, and drop the now-redundant EINTR retry loops. EINTR handling is kept only where `SA_RESTART` does not apply: `epoll_wait`/`kevent`.

### Changes
- **`main.cpp`**: `std::signal` → `sigaction` with `SA_RESTART` (explicit and portable — `signal()`'s restart behavior is platform-/feature-macro-dependent). New `InstallSignalHandler` helper documents the invariant.
- **Dropped EINTR loops** in the data path: `RawSocket::Receive` (recv/read), the netlink dump in `interface_address.cpp` (×2), and the `DefaultAddressMonitor` drain. The netlink dump's `while` loop stays — it iterates multi-datagram dumps until `NLMSG_DONE`, it was never an EINTR-retry loop.
- **Kept** EINTR handling for `epoll_wait`/`kevent` in `event_loop_dispatcher.cpp` — these are never restarted by `SA_RESTART`; the self-pipe (not EINTR-from-poll) drives prompt shutdown.
- **`application.h`**: corrected a comment that wrongly claimed `signal()` defaults to `SA_RESTART` on Linux and implied `SA_RESTART` restarts the poll.

### Latent bug fixed for free
`TcpSocket::Read`/`WriteSome`/`WriteSomeV` never looped on EINTR and treated it as a hard `Error` (`IsWouldBlockErrno(EINTR)` is false). With `SA_RESTART` that path can no longer surface EINTR.

### Notes
- No socket sets `SO_RCVTIMEO`/`SO_SNDTIMEO`, so `SA_RESTART` applies unconditionally to all data-path I/O.
- The test-util `sendto` EINTR loop (`tests/util/udp_socket.cpp`) is intentionally left: test binaries don't run under the production `SA_RESTART` handler.

## Test plan
Full gate, all green:
- Native unit (Debug, ASan/UBSan): 811/811
- Docker debug (ASan/UBSan, NET_ADMIN root tests): 803/803
- Docker release: 803/803
- Docker valgrind unit (memcheck): 803/803, no leaks, 0 errors
- e2e: 31/31
- e2e under valgrind: 31/31