### PR TITLE
Pass HTTP chunked trailers through the DIAL proxy opaquely

### DIFF
--- a/src/reflector/dial_proxy.h
+++ b/src/reflector/dial_proxy.h
@@ -42,6 +42,8 @@ public:
     static constexpr size_t MAX_RECV_BUFFER = 4 * 1024;
     static_assert(MAX_RECV_BUFFER > HttpFraming::MAX_HEADER_BYTES,
         "the receive buffer must exceed the header cap, or the always-armed reader livelocks otherwise");
+    static_assert(MAX_RECV_BUFFER > HttpFraming::MAX_TRAILER_LINE_BYTES,
+        "the receive buffer must exceed the trailer-line cap too (same livelock invariant as the header cap)");
 
     // Concurrent proxied client<->device pairs; a new accept past this is dropped. The cap that grows with
     // concurrent fetches (source clients x devices) and the only one with per-connection memory (two recv

--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -206,30 +206,34 @@ std::optional<HttpFraming::Output> HttpFraming::Feed(std::string_view input) {
             }
             pos = eol + CRLF.size();
             if (chunk_size == 0) {
-                phase_ = BodyChunkedDone;
-                chunk_remaining_ = CRLF.size();  // the blank line closing the chunked body
+                phase_ = BodyChunkedDone;  // an optional trailer section + the closing CRLF remain
             } else {
                 chunk_remaining_ = chunk_size + CRLF.size();  // chunk DATA + its terminating CRLF
             }
             break;
         }
         case BodyChunkedDone: {
-            // A chunked body closes with a bare CRLF. A trailer field (RFC 7230) would appear here instead;
-            // this framer relays bodies opaquely and has no trailer scanner, so a non-CRLF close is refused
-            // rather than silently mis-framed as the next message. The CRLF may itself be split across feeds.
-            while (chunk_remaining_ > 0 && pos < input.size()) {
-                if (input[pos] != CRLF[CRLF.size() - chunk_remaining_]) {
-                    GetLogger().Error("chunked body not closed by CRLF (chunked trailers are unsupported)");
+            // After the last chunk (RFC 7230 §4.1) comes an optional trailer section then the closing CRLF:
+            // *(trailer-field CRLF) CRLF. Relayed opaquely (no trailer parsing) -- forward each complete line
+            // and end the body at the empty line. A line without its CRLF (including a split closing CRLF) is
+            // left for the next feed, capped so a peer dribbling an endless line can't grow the buffer.
+            const size_t eol = input.find(CRLF, pos);
+            if (eol == std::string_view::npos) {
+                if (input.size() - pos > MAX_TRAILER_LINE_BYTES) {
+                    GetLogger().Error("chunked trailer line exceeds the {}-byte cap with no terminator",
+                                      MAX_TRAILER_LINE_BYTES);
                     return std::nullopt;
                 }
-                ++pos;
-                --chunk_remaining_;
+                stop = true;  // incomplete line: leave it for the next feed
+                break;
             }
-            if (chunk_remaining_ == 0) {
-                phase_ = Header;
+            const bool empty_line = eol == pos;
+            pos = eol + CRLF.size();  // forward this line (a trailer field, or the closing empty line) opaquely
+            if (empty_line) {
+                phase_ = Header;  // the empty line ends the trailer section and the chunked body
+                stop = true;
             }
-            stop = true;
-            break;
+            break;  // a trailer field: keep scanning the next line in this same feed
         }
         }
     }

--- a/src/reflector/http_message.h
+++ b/src/reflector/http_message.h
@@ -71,6 +71,11 @@ public:
     // The same unterminated-line guard for a chunk-size line (a hex length + optional chunk extensions).
     static constexpr size_t MAX_CHUNK_LINE_BYTES = 256;
 
+    // The same guard for one trailer field after the last chunk (RFC 7230 §4.1), relayed opaquely. Roomier
+    // than a chunk-size line because a trailer value can be sizable (e.g. a base64 signature digest). Kept
+    // <= MAX_HEADER_BYTES so the DIAL receive buffer, which already exceeds that, bounds it too.
+    static constexpr size_t MAX_TRAILER_LINE_BYTES = 1024;
+
     explicit HttpFraming(EndpointRewrite rewrite);
 
     // Feed a contiguous view of the owner's buffered bytes. nullopt = a malformed or over-cap message (the
@@ -90,7 +95,7 @@ private:
     Phase phase_ = Phase::Header;
     std::string header_;            // the current message's rewritten header (header views point in here)
     size_t body_remaining_ = 0;     // Content-Length bytes still to forward
-    size_t chunk_remaining_ = 0;    // current chunk DATA(+CRLF), or the closing CRLF, still to forward
+    size_t chunk_remaining_ = 0;    // current chunk DATA(+CRLF) still to forward
 };
 
 } // namespace reflector

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -717,10 +717,9 @@ TEST(HttpFramingChunkedTest, FramesMultipleChunksThenTheNextMessage) {
     ASSERT_EQ(rewrite.seen.size(), 1u);  // only msg2's Application-URL — proves msg1 ended at the 0-chunk
 }
 
-TEST(HttpFramingMiscTest, RefusesChunkedTrailers) {
-    // The framer relays bodies opaquely and has no trailer scanner, so a trailer field after the last chunk
-    // (where a bare closing CRLF is expected) is refused — the owner closes rather than forward a mis-framed
-    // stream.
+TEST(HttpFramingChunkedTest, ForwardsChunkedTrailersVerbatim) {
+    // A trailer section after the last chunk (RFC 7230 §4.1) is relayed opaquely: forwarded byte-for-byte,
+    // the empty line ends the body, and a following pipelined message is then framed and its URL rewritten.
     UrlRewrite rewrite;
     HttpFraming framing(AsRewrite(rewrite));
     Driver d{framing};
@@ -729,7 +728,60 @@ TEST(HttpFramingMiscTest, RefusesChunkedTrailers) {
         "Transfer-Encoding: chunked\r\n\r\n"
         "5\r\nhello\r\n"
         "0\r\n"
+        "X-Checksum: abc123\r\n"
+        "X-Signature: deadbeef\r\n\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Application-URL: http://10.1.3.80:36866/apps\r\n"
+        "Content-Length: 0\r\n\r\n");
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(d.out,
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "5\r\nhello\r\n"
+        "0\r\n"
+        "X-Checksum: abc123\r\n"
+        "X-Signature: deadbeef\r\n\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Application-URL: http://192.168.1.2:54321/apps\r\n"
+        "Content-Length: 0\r\n\r\n");
+    ASSERT_EQ(rewrite.seen.size(), 1u);  // only msg2's Application-URL — proves the trailers ended msg1 cleanly
+}
+
+TEST(HttpFramingChunkedTest, ReassemblesChunkedTrailerSplitAcrossFeeds) {
+    // The trailer section can arrive in arbitrary fragments — mid trailer-field line, and mid the closing
+    // CRLF. The framer holds an unterminated line for the next feed and still forwards everything verbatim.
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite));
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "5\r\nhello\r\n"
+        "0\r\n"
+        "X-Che");               // trailer field split mid-line
+    d.Read("cksum: abc123\r");  // line continues; its own CRLF is split across this feed and the next
+    d.Read("\n\r");             // field CRLF completes, and the closing CRLF is split too
+    d.Read("\n");               // closing CRLF completes — the empty line ends the body
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(d.out,
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "5\r\nhello\r\n"
+        "0\r\n"
         "X-Checksum: abc123\r\n\r\n");
+}
+
+TEST(HttpFramingMiscTest, RefusesOversizedTrailerLine) {
+    // A trailer line that never reaches its CRLF is bounded like the chunk-size line: past the cap, reject.
+    std::string message =
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "0\r\n";
+    message.append(HttpFraming::MAX_TRAILER_LINE_BYTES + 1, 'a');  // a trailer line past the cap, no CRLF
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite));
+    Driver d{framing};
+    d.Read(message);
     EXPECT_FALSE(d.ok);
 }
 


### PR DESCRIPTION
## Summary

The DIAL proxy's HTTP framer previously **refused** a chunked trailer section: after the last chunk (`0\r\n`) it expected a bare closing `\r\n` and dropped the connection as malformed on anything else, because it had no trailer scanner. This relays the trailer part through opaquely instead (RFC 7230 §4.1: `*(trailer-field CRLF) CRLF`).

### Changes
- **`http_message.cpp`** — `BodyChunkedDone` now scans the trailer section line-by-line, forwarding each complete line verbatim and ending the body at the empty line. Bodies were already a zero-copy slice, so trailers flow through unchanged; only the body-terminator detection grew a small line scanner. The no-trailer path is byte-identical to before (`eol == pos` on the closing CRLF). `chunk_remaining_` is no longer used in this phase (dropped its set in the last-chunk branch).
- **`http_message.h`** — new `MAX_TRAILER_LINE_BYTES = 1024`, bounding an unterminated trailer line the same way `MAX_CHUNK_LINE_BYTES` bounds a chunk-size line. Roomier than a chunk-size line because a trailer value can be sizable (e.g. a base64 signature digest); kept `<= MAX_HEADER_BYTES`.
- **`dial_proxy.h`** — `static_assert(MAX_RECV_BUFFER > MAX_TRAILER_LINE_BYTES)` so the always-armed-reader no-livelock invariant is pinned for the trailer cap too.

### Behavior notes
- Incremental: a trailer line (or the split closing CRLF) that arrives without its CRLF is held for the next feed, capped so a peer dribbling an endless line can't grow the buffer.
- Opaque: trailer fields are forwarded byte-for-byte, never parsed or rewritten.

### Tests
- `RefusesChunkedTrailers` → `ForwardsChunkedTrailersVerbatim` (two trailer fields + a pipelined next message proving framing resumes and the next URL is still rewritten)
- `ReassemblesChunkedTrailerSplitAcrossFeeds` (trailer field + closing CRLF fragmented across four feeds)
- `RefusesOversizedTrailerLine`

## Test plan
Full gate, all green:
- Native unit (Debug, ASan/UBSan): 813/813
- Docker debug (ASan/UBSan, NET_ADMIN root tests): 805/805
- Docker release: 805/805
- Docker valgrind unit (memcheck): 805/805, no leaks, 0 errors
- e2e: 31/31
- e2e under valgrind: 31/31