### PR TITLE
Frame close-delimited HTTP/1.0 responses in the DIAL proxy (Tier 1)

### DIFF
--- a/src/reflector/dial_proxy.cpp
+++ b/src/reflector/dial_proxy.cpp
@@ -131,8 +131,8 @@ DialProxy::Connection::Connection(DialProxy& proxy, Endpoint& owning_endpoint, T
         // node in place. c2u rewrites the client request's Host to the pinned device; u2c rewrites the device
         // response's Application-URL/Location to a freshly-minted reflector Rest listener (dropping the
         // connection if the mint fails).
-        , c2u{CreateDelegate<&Connection::RewriteHost>(this)}
-        , u2c{CreateDelegate<&Connection::RewriteRestAuthority>(this)}
+        , c2u{CreateDelegate<&Connection::RewriteHost>(this), HttpFraming::MessageType::Request}
+        , u2c{CreateDelegate<&Connection::RewriteRestAuthority>(this), HttpFraming::MessageType::Response}
         , deadline{connect_deadline} {
     ++endpoint->active_connections;  // refcount against the endpoint; the dtor decrements (RAII eviction count)
 }

--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -22,6 +22,25 @@ Logger& GetLogger() noexcept {
     return logger;
 }
 
+// The numeric status code of a response start line ("HTTP/x.y SP code SP reason"), or 0 if it can't be read.
+// Only used to spot the bodyless statuses, so a 0 just means "treat as an ordinary-bodied response".
+int ParseStatusCode(std::string_view start_line) {
+    const size_t sp = start_line.find(' ');
+    if (sp == std::string_view::npos) {
+        return 0;
+    }
+    const std::string_view code_field = TrimLeadingSpace(start_line.substr(sp + 1));
+    int code = 0;
+    const auto* const end = code_field.data() + code_field.size();
+    return std::from_chars(code_field.data(), end, code).ec == std::errc{} ? code : 0;
+}
+
+// A 1xx, 204, or 304 response has no body whatever the framing headers say (RFC 7230 §3.3.3 rule 1), so it
+// must not be taken for a close-delimited body.
+bool StatusForbidsBody(int code) {
+    return (code >= 100 && code < 200) || code == 204 || code == 304;
+}
+
 } // namespace
 
 namespace reflector {
@@ -60,8 +79,8 @@ std::optional<Authority> ParseAuthority(std::string_view value, bool bare) {
     return Authority{IpEndpoint{*addr, port}, auth_start, auth_len};
 }
 
-HttpFraming::HttpFraming(EndpointRewrite rewrite)
-    : rewrite_{std::move(rewrite)} {
+HttpFraming::HttpFraming(EndpointRewrite rewrite, MessageType type)
+    : rewrite_{std::move(rewrite)}, type_{type} {
     header_.reserve(MAX_HEADER_BYTES);
 }
 
@@ -72,6 +91,11 @@ bool HttpFraming::ScanAndRewriteHeader() {
     size_t content_length = 0;
     bool has_content_length = false;
     bool chunked = false;
+    // A response's status line can make it bodyless whatever the framing headers say (rule 1); read the code
+    // so a 1xx/204/304 is forced bodyless below, ahead of the Content-Length / chunked / close-delimited
+    // branches. Requests carry no status code, so this stays false for them.
+    const bool bodyless_status = type_ == MessageType::Response
+        && StatusForbidsBody(ParseStatusCode(std::string_view{header_}.substr(0, header_.find(CRLF))));
     size_t pos = 0;
     while (pos < header_.size()) {
         const std::string_view header_view{header_};
@@ -120,12 +144,22 @@ bool HttpFraming::ScanAndRewriteHeader() {
         pos = eol + CRLF.size();
     }
 
-    if (chunked) {
+    if (bodyless_status) {
+        // 1xx/204/304: no body whatever the framing headers say (RFC 7230 §3.3.3 rule 1). This precedes — and
+        // overrides — the Content-Length / chunked / close-delimited branches, so a stray Content-Length on
+        // such a response can't frame a phantom body that swallows the next response.
+        phase_ = Phase::Header;
+    } else if (chunked) {
         phase_ = Phase::BodyChunked;
         chunk_remaining_ = 0;
     } else if (has_content_length && content_length > 0) {
         phase_ = Phase::BodyContentLength;
         body_remaining_ = content_length;
+    } else if (type_ == MessageType::Response && !has_content_length) {
+        // A response with neither Content-Length nor chunked encoding runs until the connection closes
+        // (RFC 7230 §3.3.3 rule 7): stream the body opaquely until the owner sees EOF. A same-shape request
+        // is bodyless instead (rule 6) — the branch below.
+        phase_ = Phase::BodyUntilClose;
     } else {
         phase_ = Phase::Header;  // bodyless: the message ends at the header
     }
@@ -235,6 +269,13 @@ std::optional<HttpFraming::Output> HttpFraming::Feed(std::string_view input) {
             }
             break;  // a trailer field: keep scanning the next line in this same feed
         }
+        case BodyUntilClose:
+            // Close-delimited (RFC 7230 §3.3.3 rule 7): no length, no chunk frame. Forward all input as body,
+            // opaquely; the message has no in-band end, so the owner ends it when the connection closes. The
+            // phase never returns to Header — there is no next message on a close-delimited connection.
+            pos = input.size();
+            stop = true;
+            break;
         }
     }
 

--- a/src/reflector/http_message.h
+++ b/src/reflector/http_message.h
@@ -35,14 +35,15 @@ struct Authority {
 // fed input. Each Feed yields at most one message's worth — a complete header plus as much of its body as
 // arrived — so the owner loops Feed over its buffer until consumed == 0 (need more bytes), then reads more.
 //
-// Body framing covers exactly what DIAL needs: a Content-Length body, a Transfer-Encoding: chunked body, or
-// no body. A message carrying NEITHER header is treated as bodyless (the message ends at the blank line).
-// KNOWN LIMITATION: that means a close-delimited response (RFC 7230 §3.3.3 rule 7 — a response with no
-// Content-Length and no chunked encoding, whose body runs until the connection closes) is mis-framed: its
-// header forwards, then its body bytes are parsed as the next message's header and the connection is dropped
-// as malformed. Real DIAL device servers send Content-Length (or chunked), so this does not arise in
-// practice; a device that relied on close-delimiting would need a Phase that streams the body until EOF
-// (and status-line awareness for the always-bodyless 1xx/204/304 and HEAD-response cases). Out of scope here.
+// Body framing follows RFC 7230 §3.3.3 for what DIAL needs: a Content-Length body, a Transfer-Encoding:
+// chunked body, no body, or — for a response — a close-delimited body (no Content-Length and no chunked
+// encoding, the body running until the connection closes; rule 7, Phase::BodyUntilClose, ended by the owner
+// on EOF). Direction matters, so the framer is told its MessageType and reads the response status: a request
+// with neither framing header is bodyless (rule 6), and a 1xx/204/304 response is bodyless whatever headers
+// it carries (rule 1).
+// KNOWN LIMITATION: a response to a HEAD request is bodyless even with a Content-Length, but the framer can't
+// tell — that needs the paired request method, which lives in the opposite direction's framer. DIAL issues no
+// HEAD, so this does not arise; correlating the request method across the two framers is out of scope here.
 class HttpFraming {
 public:
     // Called once per rewritable authority header — Host (requests), Application-URL / Location
@@ -76,15 +77,21 @@ public:
     // <= MAX_HEADER_BYTES so the DIAL receive buffer, which already exceeds that, bounds it too.
     static constexpr size_t MAX_TRAILER_LINE_BYTES = 1024;
 
-    explicit HttpFraming(EndpointRewrite rewrite);
+    // Which side this framer parses. Only a response can be close-delimited — a body that runs until the
+    // connection closes (RFC 7230 §3.3.3 rule 7). A request with no Content-Length and no chunked encoding is
+    // bodyless (rule 6), so the framer must know its direction. DialProxy builds one of each per connection.
+    enum class MessageType : uint8_t { Request, Response };
+
+    HttpFraming(EndpointRewrite rewrite, MessageType type);
 
     // Feed a contiguous view of the owner's buffered bytes. nullopt = a malformed or over-cap message (the
     // owner closes); otherwise the forwardable Output.
     [[nodiscard]] std::optional<Output> Feed(std::string_view input);
 
 private:
-    // Accumulating the start line + header block, or streaming a body of a known shape.
-    enum class Phase : uint8_t { Header, BodyContentLength, BodyChunked, BodyChunkedDone };
+    // Accumulating the start line + header block, or streaming a body of a known shape. BodyUntilClose is the
+    // close-delimited response body (no Content-Length, no chunking): streamed opaquely until the close.
+    enum class Phase : uint8_t { Header, BodyContentLength, BodyChunked, BodyChunkedDone, BodyUntilClose };
 
     // Rewrites the authority headers in header_ in place and sets the body phase from its framing; returns
     // false on a malformed header. header_ holds exactly the header block, so it scans [0, header_.size()).
@@ -93,6 +100,7 @@ private:
     EndpointRewrite rewrite_;
 
     Phase phase_ = Phase::Header;
+    MessageType type_;              // request vs response: only a response can be close-delimited
     std::string header_;            // the current message's rewritten header (header views point in here)
     size_t body_remaining_ = 0;     // Content-Length bytes still to forward
     size_t chunk_remaining_ = 0;    // current chunk DATA(+CRLF) still to forward

--- a/tests/dial_proxy_test.cpp
+++ b/tests/dial_proxy_test.cpp
@@ -934,7 +934,9 @@ TEST_F(DialProxyForwardTest, TwoMessagesBackToBackDrainInOrder) {
     ASSERT_NE(oc.id, 0u);
 
     const std::string_view first = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo";
-    const std::string_view second = "HTTP/1.1 204 No Content\r\nContent-Length: 4\r\n\r\nbeef";
+    // A second bodied response — a normal 200, not a 204: a 204/304 is bodyless regardless of Content-Length
+    // (RFC 7230 §3.3.3 rule 1), so framing a body on one would be invalid (see the framer's status handling).
+    const std::string_view second = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbeef";
     std::string both;
     both.append(first);
     both.append(second);
@@ -1440,8 +1442,9 @@ TEST_F(DialProxyRewriteTest, MultiMessageDrainOnSingleEdge) {
     const std::string first = std::format(
         "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}", tricky_body.size(), tricky_body);
     const std::string_view second_body = "beef";
+    // A normal 200, not a 204: a bodyless status (RFC 7230 §3.3.3 rule 1) can't carry a Content-Length body.
     const std::string second = std::format(
-        "HTTP/1.1 204 No Content\r\nContent-Length: {}\r\n\r\n{}", second_body.size(), second_body);
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}", second_body.size(), second_body);
     const std::string both = first + second;
 
     const std::span<const std::byte> bytes{

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -161,7 +161,7 @@ TEST(HttpFramingTest, RewritesPortLessApplicationUrl) {
     // A device whose REST server is on port 80 advertises a port-less Application-URL; it is still parsed
     // (port 80 implied) and rewritten to the reflector listener.
     RecordingRewrite rewrite{Device(80), Reflector(54321)};
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read("HTTP/1.1 200 OK\r\nApplication-URL: http://10.1.3.80/apps\r\nContent-Length: 0\r\n\r\n");
     EXPECT_TRUE(d.ok);
@@ -171,7 +171,7 @@ TEST(HttpFramingTest, RewritesPortLessApplicationUrl) {
 
 TEST(HttpFramingTest, ForwardsUnchangedWhenNothingIsRewritten) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     const std::string msg{
         "HTTP/1.1 200 OK\r\n"
@@ -187,7 +187,7 @@ TEST(HttpFramingTest, HeaderIsRewrittenCopyBodyIsAZeroCopySliceOfInput) {
     // Locks the two-view contract: `header` is the rewritten copy (in HttpFraming's scratch), `body` points
     // straight into the fed input, and `consumed` covers the whole message.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     const std::string msg =
         "HTTP/1.1 200 OK\r\n"
         "Application-URL: http://10.1.3.80:36866/apps\r\n"
@@ -206,7 +206,7 @@ TEST(HttpFramingTest, HeaderIsRewrittenCopyBodyIsAZeroCopySliceOfInput) {
 
 TEST(HttpFramingTest, IncompleteHeaderConsumesNothing) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     const auto r = framing.Feed(
         "HTTP/1.1 200 OK\r\n"
         "Application-URL: http://10.1.3");
@@ -218,7 +218,7 @@ TEST(HttpFramingTest, IncompleteHeaderConsumesNothing) {
 
 TEST(HttpFramingTest, ReassemblesHeaderBlockSplitAcrossFeeds) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -245,7 +245,7 @@ TEST(HttpFramingContentLengthTest, RewritesApplicationUrlAndForwardsBodyVerbatim
         "Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
 
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
 
@@ -265,7 +265,7 @@ TEST(HttpFramingContentLengthTest, MatchesApplicationUrlHeaderNameCaseInsensitiv
         "application-url: http://10.1.3.80:36866/apps\r\n"
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out,
@@ -276,7 +276,7 @@ TEST(HttpFramingContentLengthTest, MatchesApplicationUrlHeaderNameCaseInsensitiv
 
 TEST(HttpFramingContentLengthTest, ReassemblesBodySplitAcrossFeeds) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -291,7 +291,7 @@ TEST(HttpFramingContentLengthTest, ReassemblesBodySplitAcrossFeeds) {
 
 TEST(HttpFramingContentLengthTest, ContinuingBodyFeedCarriesNoHeader) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     const auto r1 = framing.Feed(
         "HTTP/1.1 200 OK\r\n"
         "Content-Length: 5\r\n\r\n"
@@ -314,7 +314,7 @@ TEST(HttpFramingMiscTest, ForwardsABodyLargerThanTheHeaderCap) {
         "HTTP/1.1 200 OK\r\n"
         "Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_TRUE(d.ok);
@@ -329,7 +329,7 @@ TEST(HttpFramingChunkedTest, RewritesUppercaseLocationAndForwardsChunksVerbatim)
         "1a\r\n<service><ok>true</ok></s>\r\n"
         "0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
 
@@ -343,7 +343,7 @@ TEST(HttpFramingChunkedTest, RewritesUppercaseLocationAndForwardsChunksVerbatim)
 
 TEST(HttpFramingChunkedTest, ReassemblesChunkBoundariesSplitAcrossFeeds) {
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -367,7 +367,7 @@ TEST(HttpFramingMiscTest, RewritesRequestHostFromReflectorToDevice) {
         "Host: 192.168.1.2:40000\r\n"
         "Connection: keep-alive\r\n\r\n";
     HostRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Request);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out,
@@ -386,7 +386,7 @@ TEST(HttpFramingMiscTest, RefusesOversizedHeaderBlock) {
         "X-Pad: ";
     message.append(3 * 1024, 'a');  // exceeds the header cap, no terminating blank line
     HostRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Request);
     Driver d{framing};
     d.Read(message);
     EXPECT_FALSE(d.ok);
@@ -402,7 +402,7 @@ TEST(HttpFramingMiscTest, FramesTwoPipelinedKeepAliveMessages) {
         "HTTP/1.1 204 No Content\r\n"
         "Application-URL: http://10.1.3.80:36866/apps\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(first + second);
     EXPECT_EQ(d.out,
@@ -420,7 +420,7 @@ TEST(HttpFramingTest, EmitsAMessageThenCarriesAPartialNextHeader) {
     // rewritten. The first read forwards msg1 and leaves msg2's partial header unconsumed (it stays in the
     // owner's buffer); the second read completes and rewrites msg2.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -454,7 +454,7 @@ TEST(HttpFramingTest, RewritesMultipleAuthorityHeadersInOneMessage) {
         "Location: http://10.1.3.80:36866/apps/YouTube\r\n"
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out,
@@ -478,7 +478,7 @@ TEST(HttpFramingTest, ScanDoesNotShortCircuitWhenAnEarlierHeaderIsAccepted) {
         "Location: http://10.1.3.80:40000/apps/YouTube\r\n"   // NOT owned -> declined, left verbatim
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;  // only swaps 10.1.3.80:36866
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     const auto r = framing.Feed(message);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(r->consumed, message.size());  // the whole message consumed despite the second decline
@@ -501,7 +501,7 @@ TEST(HttpFramingTest, LeavesAuthorityUnchangedWhenRewriteDeclines) {
         "Application-URL: http://10.1.3.80:9999/apps\r\n"
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;  // only swaps 10.1.3.80:36866
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out, message);
@@ -517,7 +517,7 @@ TEST(HttpFramingTest, LeavesHostnameUrlAuthorityUnchanged) {
         "Application-URL: http://dial.example.com:36866/apps\r\n"
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out, message);
@@ -532,7 +532,7 @@ TEST(HttpFramingTest, LeavesNonHttpUrlsUnchanged) {
         "Application-URL: https://10.1.3.80:36866/apps\r\n"
         "Content-Length: 0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out, message);
@@ -544,7 +544,7 @@ TEST(HttpFramingChunkedTest, ChunkedTakesPrecedenceOverContentLength) {
     // (deliberately wrong) Content-Length must not bound the body — a following pipelined message proves msg1
     // ended at the chunk terminator, since only then is msg2 framed and its Application-URL rewritten.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -571,7 +571,7 @@ TEST(HttpFramingChunkedTest, TreatsChunkedCodingCaseInsensitivelyInACodingList) 
     // RFC 7230: the transfer-coding name is case-insensitive and chunked may end a coding list. "gzip, CHUNKED"
     // must frame as chunked — otherwise the chunk bytes would be misread as the next message's header.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -594,7 +594,7 @@ TEST(HttpFramingChunkedTest, DropsChunkExtensionsWhenSizingButForwardsThemVerbat
         "3;name=value\r\nabc\r\n"
         "0\r\n\r\n";
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_EQ(d.out, message);
@@ -604,7 +604,7 @@ TEST(HttpFramingMiscTest, RefusesMalformedContentLength) {
     // A Content-Length whose value isn't a number is malformed: reject the message so the owner closes, rather
     // than guess a body length.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -617,7 +617,7 @@ TEST(HttpFramingMiscTest, RefusesContentLengthWithTrailingJunk) {
     // and frame a 5-byte body, mis-parsing the trailing "abc" as the next message. Require the whole value to
     // be the number: reject so the owner closes (matching ParseAuthority's port strictness).
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -629,7 +629,7 @@ TEST(HttpFramingMiscTest, AcceptsContentLengthWithTrailingWhitespace) {
     // Trailing OWS after the number is legal (RFC 7230 §3.2.4) and must NOT be mistaken for junk: the value is
     // still 5, and the body frames normally.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -641,7 +641,7 @@ TEST(HttpFramingMiscTest, AcceptsContentLengthWithTrailingWhitespace) {
 TEST(HttpFramingMiscTest, RefusesMalformedChunkSize) {
     // A chunk-size line that isn't valid hex is malformed: reject so the owner closes.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -657,7 +657,7 @@ TEST(HttpFramingMiscTest, RefusesOversizedChunkSizeLine) {
         "Transfer-Encoding: chunked\r\n\r\n";
     message.append(300, 'a');  // a chunk-size line well past MAX_CHUNK_LINE_BYTES (256), no CRLF
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_FALSE(d.ok);
@@ -668,7 +668,7 @@ TEST(HttpFramingTest, RewritesMultipleHeadersThenFramesTheNextMessage) {
     // body, then a second message follows. The next message must frame from the right offset — consumed
     // tracks the original input bytes, not the grown rewritten header.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -694,7 +694,7 @@ TEST(HttpFramingChunkedTest, FramesMultipleChunksThenTheNextMessage) {
     // and trailing CRLF must be consumed in turn, the 0-chunk must end the body, and only then is the next
     // message's header framed and rewritten.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -721,7 +721,7 @@ TEST(HttpFramingChunkedTest, ForwardsChunkedTrailersVerbatim) {
     // A trailer section after the last chunk (RFC 7230 §4.1) is relayed opaquely: forwarded byte-for-byte,
     // the empty line ends the body, and a following pipelined message is then framed and its URL rewritten.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -751,7 +751,7 @@ TEST(HttpFramingChunkedTest, ReassemblesChunkedTrailerSplitAcrossFeeds) {
     // The trailer section can arrive in arbitrary fragments — mid trailer-field line, and mid the closing
     // CRLF. The framer holds an unterminated line for the next feed and still forwards everything verbatim.
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(
         "HTTP/1.1 200 OK\r\n"
@@ -779,10 +779,94 @@ TEST(HttpFramingMiscTest, RefusesOversizedTrailerLine) {
         "0\r\n";
     message.append(HttpFraming::MAX_TRAILER_LINE_BYTES + 1, 'a');  // a trailer line past the cap, no CRLF
     UrlRewrite rewrite;
-    HttpFraming framing(AsRewrite(rewrite));
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
     Driver d{framing};
     d.Read(message);
     EXPECT_FALSE(d.ok);
+}
+
+TEST(HttpFramingCloseDelimitedTest, StreamsResponseWithNoLengthAsBodyUntilClose) {
+    // A response with neither Content-Length nor chunked encoding (HTTP/1.0, or HTTP/1.1 Connection: close) is
+    // close-delimited (RFC 7230 §3.3.3 rule 7): the body streams opaquely across feeds with no in-band end —
+    // the owner ends it at connection close. The header is still rewritten; body bytes that resemble a new
+    // status line stay body, never re-framed (the mis-framing bug this fixes).
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.0 200 OK\r\n"
+        "Application-URL: http://10.1.3.80:36866/apps\r\n\r\n"
+        "<dial>part1");
+    d.Read("HTTP/1.1 still body\r\npart2");  // header-looking bytes inside the body stay body
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(d.out,
+        "HTTP/1.0 200 OK\r\n"
+        "Application-URL: http://192.168.1.2:54321/apps\r\n\r\n"
+        "<dial>part1HTTP/1.1 still body\r\npart2");
+    ASSERT_EQ(rewrite.seen.size(), 1u);  // only the real header's Application-URL — the body is never re-scanned
+}
+
+TEST(HttpFramingCloseDelimitedTest, RequestWithNoLengthIsBodylessNotCloseDelimited) {
+    // A request with neither Content-Length nor chunked encoding has a zero-length body (RFC 7230 §3.3.3
+    // rule 6) — NOT close-delimited. Two pipelined requests must both frame; a close-delimited first would
+    // swallow the second as its body.
+    HostRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Request);
+    Driver d{framing};
+    d.Read(
+        "GET /a HTTP/1.1\r\nHost: 192.168.1.2:40000\r\n\r\n"
+        "GET /b HTTP/1.1\r\nHost: 192.168.1.2:40000\r\n\r\n");
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(d.out,
+        "GET /a HTTP/1.1\r\nHost: 10.1.3.80:1461\r\n\r\n"
+        "GET /b HTTP/1.1\r\nHost: 10.1.3.80:1461\r\n\r\n");
+    EXPECT_EQ(rewrite.seen.size(), 2u);  // both framed — the first request was not close-delimited
+}
+
+TEST(HttpFramingCloseDelimitedTest, BodylessStatusResponsesAreNotCloseDelimited) {
+    // 1xx/204/304 responses are bodyless even with no Content-Length (RFC 7230 §3.3.3 rule 1), so they must
+    // NOT be treated as close-delimited: a following pipelined response on the same connection still frames.
+    const auto check = [](std::string_view status_line) {
+        UrlRewrite rewrite;
+        HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+        Driver d{framing};
+        d.Read(std::string{status_line} +
+            "\r\nApplication-URL: http://10.1.3.80:36866/apps\r\n\r\n"
+            "HTTP/1.1 200 OK\r\nApplication-URL: http://10.1.3.80:36866/apps\r\nContent-Length: 0\r\n\r\n");
+        EXPECT_TRUE(d.ok) << status_line;
+        EXPECT_EQ(rewrite.seen.size(), 2u) << status_line;  // both framed — the status did not swallow #2 as body
+    };
+    check("HTTP/1.1 204 No Content");
+    check("HTTP/1.1 304 Not Modified");
+    check("HTTP/1.1 100 Continue");
+}
+
+TEST(HttpFramingCloseDelimitedTest, BodylessStatusWithContentLengthHasNoBody) {
+    // RFC 7230 §3.3.3 rule 1 overrides the framing headers: a 304 that (wrongly) carries a Content-Length is
+    // still bodyless. The CL must frame no phantom body, or it would swallow the start of the next response.
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.1 304 Not Modified\r\n"
+        "Application-URL: http://10.1.3.80:36866/apps\r\n"
+        "Content-Length: 50\r\n\r\n"
+        "HTTP/1.1 200 OK\r\nApplication-URL: http://10.1.3.80:36866/apps\r\nContent-Length: 0\r\n\r\n");
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(rewrite.seen.size(), 2u);  // both framed — the 304's Content-Length framed no body
+}
+
+TEST(HttpFramingCloseDelimitedTest, ExplicitZeroContentLengthResponseIsNotCloseDelimited) {
+    // Content-Length: 0 is an explicit empty body, distinct from the "no length header" case — it must stay
+    // bodyless, so a following pipelined response frames rather than being swallowed.
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.1 200 OK\r\nApplication-URL: http://10.1.3.80:36866/apps\r\nContent-Length: 0\r\n\r\n"
+        "HTTP/1.1 200 OK\r\nApplication-URL: http://10.1.3.80:36866/apps\r\nContent-Length: 0\r\n\r\n");
+    EXPECT_TRUE(d.ok);
+    EXPECT_EQ(rewrite.seen.size(), 2u);  // both framed — CL:0 is bodyless, not close-delimited
 }
 
 }  // namespace reflector


### PR DESCRIPTION
## Summary

DIAL devices may serve **close-delimited** responses (HTTP/1.0, or HTTP/1.1 `Connection: close`): no `Content-Length`, no `Transfer-Encoding: chunked`, the body running until the connection closes (RFC 7230 §3.3.3 rule 7). The framer previously treated these as **bodyless**, so the body was mis-parsed as the next message's header and the connection dropped as malformed (the `KNOWN LIMITATION` in the framer's class doc). This frames them correctly.

This is **Tier 1** of the agreed plan; the proxy-side graceful drain for a slow client at EOF is **Tier 2** (separate PR).

### Changes
- **Direction awareness** — `HttpFraming` gains a `MessageType { Request, Response }` ctor arg; `DialProxy::Connection` builds `c2u = Request`, `u2c = Response`. Only a response can be close-delimited; a request with no length is bodyless (rule 6).
- **Status parsing** — parse the response status code. `1xx`/`204`/`304` are bodyless whatever the framing headers say (rule 1), and this **takes precedence over `Content-Length`/chunked** — so a `304` that echoes a `Content-Length` with no body doesn't frame a phantom body that swallows the next response.
- **`Phase::BodyUntilClose`** — streams the body opaquely until the owner sees EOF; never returns to `Header` (a close-delimited connection has no next message). The proxy's existing `Read == Closed → Abort` already delivers the streamed body + a graceful FIN for a keeping-up client, so no proxy change is needed in Tier 1.

### Verified
A 4-agent adversarial review confirmed the body-length decision against RFC §3.3.3, the `Feed`/`BodyUntilClose` edge behavior, the "no proxy change needed" claim (slow-client truncation is the pre-existing Tier-2 gap, not a regression), and the test audit. The review prompted the rule-1-over-`Content-Length` precedence fix.

### Tests
New (`http_message_test.cpp`): close-delimited streaming across feeds (including header-looking body bytes staying body — the anti-regression for the original bug), request-stays-bodyless, `1xx`/`204`/`304` not close-delimited, bodyless-status-overrides-`Content-Length`, explicit `CL:0` stays bodyless. All other constructions gained an explicit `MessageType`.

Two `DialProxy` drain tests (`dial_proxy_test.cpp`) used a `204 No Content` carrying a `Content-Length` body as their second pipelined message — invalid under rule 1 (a `204` is bodyless). Their second message is now a normal `200 OK`, preserving each test's intent (drain two pipelined bodied responses in order).

## Test plan
Full gate, all green:
- Native unit (Debug, ASan/UBSan): 818/818
- Docker debug (ASan/UBSan, NET_ADMIN root tests): 810/810
- Docker release: 810/810
- Docker valgrind unit (memcheck): 810/810, no leaks, 0 errors
- e2e: 31/31
- e2e under valgrind: 31/31

## Follow-ups (not in this PR)
- **Tier 2**: graceful drain of a slow client's buffered tail before FIN on upstream EOF (pre-existing truncation window, widened slightly by close-delimiting).
- **Orthogonal hardening** (surfaced by the review): multiple conflicting `Content-Length` headers are not rejected (RFC §3.3.3) — a pre-existing request-smuggling-class gap, independent of this change.