### PR TITLE
fix: refuse chunk sizes that would overflow the DIAL framer

### DIFF
--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -8,6 +8,7 @@
 #include <charconv>
 #include <cstdint>
 #include <format>
+#include <limits>
 #include <utility>
 
 namespace {
@@ -241,6 +242,10 @@ std::optional<HttpFraming::Output> HttpFraming::Feed(std::string_view input) {
             pos = eol + CRLF.size();
             if (chunk_size == 0) {
                 phase_ = BodyChunkedDone;  // an optional trailer section + the closing CRLF remain
+            } else if (chunk_size > std::numeric_limits<size_t>::max() - CRLF.size()) {
+                // A near-SIZE_MAX size (hostile/buggy device) would wrap the addition below and misframe.
+                GetLogger().Error("chunk size {:#x} too large to frame", chunk_size);
+                return std::nullopt;
             } else {
                 chunk_remaining_ = chunk_size + CRLF.size();  // chunk DATA + its terminating CRLF
             }

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <format>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -648,6 +650,36 @@ TEST(HttpFramingMiscTest, RefusesMalformedChunkSize) {
         "Transfer-Encoding: chunked\r\n\r\n"
         "zz\r\n");
     EXPECT_FALSE(d.ok);
+}
+
+TEST(HttpFramingMiscTest, RefusesChunkSizeThatWouldOverflowTheFramer) {
+    // SIZE_MAX and SIZE_MAX-1 parse as valid hex, but adding the chunk's trailing CRLF would wrap
+    // chunk_remaining_ to 1 or 0 and desynchronize the framer: reject so the owner closes.
+    for (const size_t chunk_size : {std::numeric_limits<size_t>::max(),
+                                    std::numeric_limits<size_t>::max() - 1}) {
+        UrlRewrite rewrite;
+        HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+        Driver d{framing};
+        d.Read(std::format("HTTP/1.1 200 OK\r\n"
+                           "Transfer-Encoding: chunked\r\n\r\n"
+                           "{:x}\r\n",
+                           chunk_size));
+        EXPECT_FALSE(d.ok);
+    }
+}
+
+TEST(HttpFramingChunkedTest, AcceptsTheLargestFrameableChunkSize) {
+    // SIZE_MAX-2 is the boundary: chunk DATA + CRLF fits size_t exactly, so the guard must not
+    // over-reject it and the chunk bytes stream through opaquely.
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(std::format("HTTP/1.1 200 OK\r\n"
+                       "Transfer-Encoding: chunked\r\n\r\n"
+                       "{:x}\r\ndata",
+                       std::numeric_limits<size_t>::max() - 2));
+    EXPECT_TRUE(d.ok);
+    EXPECT_TRUE(d.out.ends_with("data"));
 }
 
 TEST(HttpFramingMiscTest, RefusesOversizedChunkSizeLine) {


### PR DESCRIPTION
A chunk-size line of `ffffffffffffffff` (or one less) parses cleanly, but adding the trailing-CRLF allowance wraps `chunk_remaining_` to 1 (or 0) — defined unsigned wrap, so no sanitizer trips — and the framer then reads the peer's chunk payload as the next chunk-size line, desynchronizing the proxied stream. A hostile or buggy DIAL device on the LAN can trigger this.

Reject any size the addition can't fit; the owner drops and closes as with any other malformed framing. Mirrors the Rust implementation's `checked_add` guard (`net/http/framing.rs`, `ChunkSizeTooLarge`).

Tests: `SIZE_MAX` and `SIZE_MAX-1` refused (fails without the fix), `SIZE_MAX-2` — the largest frameable size — still accepted. Values are derived from `size_t`, so the same cases cover the 32-bit boundary on armv7.