### PR TITLE
feat: react to link events in the address monitor

### DIFF
--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -32,13 +32,15 @@ Logger& GetLogger() noexcept {
     return logger;
 }
 
-// A single address notification is small and bounded — an ifaddrmsg / ifa_msghdr plus a few short
-// attributes — with none of the large per-interface blocks that force the RTM_GETLINK dump to grow
-// its buffer. The kernel delivers each notification as its own datagram, so 4 KB comfortably holds
-// one and the receive buffer never has to grow.
-constexpr size_t NOTIFICATION_BUFFER_SIZE = 4 * 1024;
+// The kernel delivers each notification as its own datagram, never a coalesced dump. Sized for
+// the largest: an RTM_NEWLINK carries the interface's whole attribute set (stats, IFLA_AF_SPEC,
+// VF info) at ~1 KB; address notifications are far smaller. 8 KB is roomy either way.
+constexpr size_t NOTIFICATION_BUFFER_SIZE = 8 * 1024;
 
 void AddUnique(std::vector<unsigned>& indices, unsigned index) {
+    if (index == 0) {
+        return;  // names no interface (kernel indices are >= 1) — and 0 is the refresh-all sentinel
+    }
     if (std::ranges::find(indices, index) == indices.end()) {
         indices.push_back(index);
     }
@@ -86,9 +88,9 @@ bool DefaultAddressMonitor::Open() noexcept {
 
     sockaddr_nl address{};
     address.nl_family = AF_NETLINK;
-    address.nl_groups = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR;
+    address.nl_groups = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR | RTMGRP_LINK;
     if (bind(fd_.Get(), reinterpret_cast<const sockaddr*>(&address), sizeof(address)) != 0) {
-        GetLogger().Error("Cannot subscribe to netlink address groups: {}", Error::FromErrno());
+        GetLogger().Error("Cannot subscribe to netlink notification groups: {}", Error::FromErrno());
         return false;
     }
 #else
@@ -194,6 +196,9 @@ void DefaultAddressMonitor::CollectChangedInterfaces(std::span<const std::byte> 
         if (header->nlmsg_type == RTM_NEWADDR || header->nlmsg_type == RTM_DELADDR) {
             const auto* address = static_cast<const ifaddrmsg*>(NLMSG_DATA(header));
             AddUnique(changed, address->ifa_index);
+        } else if (header->nlmsg_type == RTM_NEWLINK || header->nlmsg_type == RTM_DELLINK) {
+            const auto* link = static_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            AddUnique(changed, static_cast<unsigned>(link->ifi_index));
         }
     }
 }
@@ -218,7 +223,11 @@ void DefaultAddressMonitor::CollectChangedInterfaces(std::span<const std::byte> 
 
         const auto type = std::to_integer<u_char>(messages[offset + offsetof(rt_msghdr, rtm_type)]);
         constexpr size_t index_end = offsetof(ifa_msghdr, ifam_index) + sizeof(u_short);
-        if ((type == RTM_NEWADDR || type == RTM_DELADDR) && message_length >= index_end) {
+        // A link/MAC change arrives as RTM_IFINFO (if_msghdr), whose index sits at the same
+        // offset as ifa_msghdr's — asserted here so one read handles both shapes.
+        static_assert(offsetof(if_msghdr, ifm_index) == offsetof(ifa_msghdr, ifam_index));
+        if ((type == RTM_NEWADDR || type == RTM_DELADDR || type == RTM_IFINFO)
+                && message_length >= index_end) {
             u_short index = 0;
             std::memcpy(&index, messages.data() + offset + offsetof(ifa_msghdr, ifam_index), sizeof(index));
             AddUnique(changed, index);

--- a/src/reflector/default_address_monitor.h
+++ b/src/reflector/default_address_monitor.h
@@ -12,9 +12,10 @@
 namespace reflector {
 
 // Production AddressMonitor. Linux uses a NETLINK_ROUTE socket subscribed to the IPv4/IPv6 address
-// groups; macOS uses a PF_ROUTE socket. The notification socket is opened at construction; the fd
-// is registered with the Dispatcher in Start(). The monitor owns that registration, so it must be
-// destroyed before the Dispatcher it was given.
+// groups and the link group (a MAC change is a link event, not an address one); macOS uses a
+// PF_ROUTE socket. The notification socket is opened at construction; the fd is registered with
+// the Dispatcher in Start(). The monitor owns that registration, so it must be destroyed before
+// the Dispatcher it was given.
 class DefaultAddressMonitor : public AddressMonitor, NoMove {
 public:
     explicit DefaultAddressMonitor(Dispatcher& dispatcher);

--- a/tests/default_address_monitor_test.cpp
+++ b/tests/default_address_monitor_test.cpp
@@ -54,9 +54,26 @@ void AppendAddrMessage(std::vector<std::byte>& out, uint16_t type, uint32_t inte
     std::memcpy(out.data() + start + sizeof(nlmsghdr), &message, sizeof(message));
 }
 
+// Appends one netlink link message (nlmsghdr + ifinfomsg) of the given type carrying ifi_index —
+// the shape a MAC or link-state change arrives in.
+void AppendLinkMessage(std::vector<std::byte>& out, uint16_t type, int interface_index) {
+    nlmsghdr header{};
+    header.nlmsg_len = reflector::narrow_cast<uint32_t>(sizeof(nlmsghdr) + sizeof(ifinfomsg));
+    header.nlmsg_type = type;
+    ifinfomsg message{};
+    message.ifi_index = interface_index;
+
+    const size_t start = out.size();
+    out.resize(start + header.nlmsg_len);
+    std::memcpy(out.data() + start, &header, sizeof(header));
+    std::memcpy(out.data() + start + sizeof(nlmsghdr), &message, sizeof(message));
+}
+
 constexpr uint16_t ADDR_MESSAGE = RTM_NEWADDR;
 constexpr uint16_t DELETED_ADDR_MESSAGE = RTM_DELADDR;
-constexpr uint16_t NON_ADDR_MESSAGE = RTM_NEWLINK;
+constexpr uint16_t LINK_MESSAGE = RTM_NEWLINK;
+constexpr uint16_t REMOVED_LINK_MESSAGE = RTM_DELLINK;
+constexpr uint16_t UNRELATED_MESSAGE = RTM_NEWROUTE;
 
 #else
 
@@ -75,9 +92,24 @@ void AppendAddrMessage(std::vector<std::byte>& out, unsigned char type, uint16_t
     std::memcpy(out.data() + start, &message, sizeof(message));
 }
 
+// Appends one PF_ROUTE link message (if_msghdr, the RTM_IFINFO shape) carrying ifm_index.
+void AppendLinkMessage(std::vector<std::byte>& out, unsigned char type, uint16_t interface_index) {
+    if_msghdr message{};
+    message.ifm_msglen = static_cast<unsigned short>(sizeof(if_msghdr));
+    message.ifm_version = RTM_VERSION;
+    message.ifm_type = type;
+    message.ifm_index = interface_index;
+
+    const size_t start = out.size();
+    out.resize(start + sizeof(if_msghdr));
+    std::memcpy(out.data() + start, &message, sizeof(message));
+}
+
 constexpr unsigned char ADDR_MESSAGE = RTM_NEWADDR;
 constexpr unsigned char DELETED_ADDR_MESSAGE = RTM_DELADDR;
-constexpr unsigned char NON_ADDR_MESSAGE = RTM_IFINFO;
+constexpr unsigned char LINK_MESSAGE = RTM_IFINFO;
+constexpr unsigned char REMOVED_LINK_MESSAGE = RTM_IFINFO;  // one link-change type covers both
+constexpr unsigned char UNRELATED_MESSAGE = RTM_ADD;
 
 #endif
 
@@ -204,18 +236,63 @@ TEST_F(DefaultAddressMonitorTest, CoalescesAcrossReads) {
     EXPECT_EQ(sink.changed, (std::vector<unsigned>{8}));
 }
 
-TEST_F(DefaultAddressMonitorTest, IgnoresNonAddressMessages) {
+TEST_F(DefaultAddressMonitorTest, ReportsLinkChanges) {
+    // A MAC or link-state change arrives as a link message, not an address one; it must refresh
+    // that interface too, or injected frames keep the stale cached MAC.
     auto monitor = MakeMonitor();
     ASSERT_TRUE(StartWatching(monitor));
     std::vector<std::byte> messages;
-    AppendAddrMessage(messages, NON_ADDR_MESSAGE, 3);
+    AppendLinkMessage(messages, LINK_MESSAGE, 9);
+    AppendLinkMessage(messages, REMOVED_LINK_MESSAGE, 2);
+
+    Write(messages);
+    FireReadable();
+
+    EXPECT_EQ(sink.changed, (std::vector<unsigned>{9, 2}));
+}
+
+TEST_F(DefaultAddressMonitorTest, CoalescesAddressAndLinkChangesForOneInterface) {
+    auto monitor = MakeMonitor();
+    ASSERT_TRUE(StartWatching(monitor));
+    std::vector<std::byte> messages;
+    AppendAddrMessage(messages, ADDR_MESSAGE, 3);
+    AppendLinkMessage(messages, LINK_MESSAGE, 3);  // same interface: one callback, not two
+    AppendLinkMessage(messages, LINK_MESSAGE, 5);
+
+    Write(messages);
+    FireReadable();
+
+    EXPECT_EQ(sink.changed, (std::vector<unsigned>{3, 5}));
+}
+
+TEST_F(DefaultAddressMonitorTest, IgnoresUnrelatedMessages) {
+    auto monitor = MakeMonitor();
+    ASSERT_TRUE(StartWatching(monitor));
+    std::vector<std::byte> messages;
+    AppendAddrMessage(messages, UNRELATED_MESSAGE, 3);  // a route message: not an addr/link change
     AppendAddrMessage(messages, ADDR_MESSAGE, 4);
-    AppendAddrMessage(messages, NON_ADDR_MESSAGE, 6);
+    AppendAddrMessage(messages, UNRELATED_MESSAGE, 6);
 
     Write(messages);
     FireReadable();
 
     EXPECT_EQ(sink.changed, (std::vector<unsigned>{4}));
+}
+
+TEST_F(DefaultAddressMonitorTest, NeverForwardsIndexZero) {
+    // 0 names no interface (kernel indices are >= 1) and is the overflow path's refresh-all
+    // sentinel — a stray 0 in a kernel message must not masquerade as it.
+    auto monitor = MakeMonitor();
+    ASSERT_TRUE(StartWatching(monitor));
+    std::vector<std::byte> messages;
+    AppendAddrMessage(messages, ADDR_MESSAGE, 0);
+    AppendLinkMessage(messages, LINK_MESSAGE, 0);
+    AppendAddrMessage(messages, ADDR_MESSAGE, 6);
+
+    Write(messages);
+    FireReadable();
+
+    EXPECT_EQ(sink.changed, (std::vector<unsigned>{6}));
 }
 
 TEST_F(DefaultAddressMonitorTest, IgnoresSpuriousWakeWithNoData) {


### PR DESCRIPTION
A MAC change arrives as `RTM_NEWLINK` (`RTM_IFINFO` on the BSDs), not an address event, so the monitor never saw it: every injected frame kept the stale cached MAC until some unrelated address change forced a refresh. Ports the Rust monitor's link subscription (`interface/address_monitor/rtnetlink.rs`, `route.rs`).

- Linux: subscribe `RTMGRP_LINK`, report the `ifinfomsg` index for `RTM_NEWLINK`/`RTM_DELLINK`.
- BSD: also accept `RTM_IFINFO`; `if_msghdr` carries its index at the same offset as `ifa_msghdr`, asserted at compile time, so the existing read covers both shapes. Link flaps trigger a refresh too — a per-interface resolve is cheap, missing a MAC change is not.
- Notification buffer 4 → 8 KB (an `RTM_NEWLINK` carries the interface's whole attribute set at ~1 KB).
- Index 0 from a parsed message is never forwarded: it names no interface and doubles as the overflow path's refresh-all sentinel.

The old `IgnoresNonAddressMessages` test used link types as its ignored kind — that expectation inverted by design. Replaced with link-reported, mixed addr+link coalescing, unrelated-type (route message), and index-zero cases.