### PR TITLE
ci: publish images as <owner>/reflector, without the latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/reflector,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
@@ -303,29 +303,30 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/reflector
+          # Deliberately no "latest": that tag belongs to the Rust images; this repo releases
+          # version tags on the 0.7.x line only.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
 
       - name: Create and push the manifest list
         working-directory: /tmp/digests
         env:
-          REPO: ${{ github.repository }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
           METADATA: ${{ steps.meta.outputs.json }}
         run: |
           mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
           args=()
           for tag in "${tags[@]}"; do args+=(--tag "$tag"); done
-          for f in *.digest; do args+=("ghcr.io/${REPO}@sha256:${f%.digest}"); done
+          for f in *.digest; do args+=("${IMAGE}@sha256:${f%.digest}"); done
           docker buildx imagetools create "${args[@]}"
 
       - name: Inspect
         env:
-          REPO: ${{ github.repository }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
           VERSION: ${{ steps.meta.outputs.version }}
-        run: docker buildx imagetools inspect "ghcr.io/${REPO}:${VERSION}"
+        run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
   release:
     name: GitHub release

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Requires Docker with Buildx.
 ./docker_build.sh --push
 ```
 
-The runtime image uses pinned Debian/distroless base image digests. By default, `./docker_build.sh` loads a single-platform image into the local Docker engine and tags it as `reflector:<version>` and `reflector:latest`. With `--push`, it publishes `ghcr.io/sbogomolov/reflector` as a multi-platform manifest for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; override the destination with `--image`, or override architectures with `--platforms` for unusual deployment targets.
+The runtime image uses pinned Debian/distroless base image digests. By default, `./docker_build.sh` loads a single-platform image into the local Docker engine and tags it as `reflector:<version>`. With `--push`, it publishes `ghcr.io/sbogomolov/reflector` as a multi-platform manifest for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; override the destination with `--image`, or override architectures with `--platforms` for unusual deployment targets.
 
 ## Run
 
@@ -143,7 +143,7 @@ must run as root. To run unprivileged, grant a group read/write on `/dev/bpf*` w
 
 ### Run in Docker
 
-Prebuilt multi-arch images are published to `ghcr.io/sbogomolov/reflector`, tagged `latest` and per release version, for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the variant matching the host. The image is a single static binary on `scratch` — no shell, no package manager. Its entrypoint is the reflector with no default argument, so it configures itself from `REFLECTOR_*` [environment variables](#environment-variables); pass a config file path to use a file instead.
+Prebuilt multi-arch images are published to `ghcr.io/sbogomolov/reflector`, tagged per release version plus the moving `0.7` minor tag, for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the variant matching the host. The `latest` tag tracks the Rust implementation, not this one. The image is a single static binary on `scratch` — no shell, no package manager. Its entrypoint is the reflector with no default argument, so it configures itself from `REFLECTOR_*` [environment variables](#environment-variables); pass a config file path to use a file instead.
 
 Because the reflector captures at L2 on each interface, the container must be **on the real segments it bridges**, not on a default NAT bridge network (which would hide that traffic from it). On a Linux host, `--network host` is the simplest way. Configure it with `-e` variables:
 
@@ -153,7 +153,7 @@ docker run --rm \
     -e REFLECTOR_TV_SOURCE_IF=eth0 \
     -e REFLECTOR_TV_TARGET_IF=eth1 \
     -e REFLECTOR_TV_MDNS=true \
-    ghcr.io/sbogomolov/reflector:latest
+    ghcr.io/sbogomolov/reflector:0.7
 ```
 
 `CAP_NET_RAW` is required (see [Runtime privileges](#runtime-privileges)) and is in Docker's default capability set, so the command above works as-is. For least privilege, drop everything else and grant just that one:
@@ -165,7 +165,7 @@ docker run --rm \
     -e REFLECTOR_TV_SOURCE_IF=eth0 \
     -e REFLECTOR_TV_TARGET_IF=eth1 \
     -e REFLECTOR_TV_MDNS=true \
-    ghcr.io/sbogomolov/reflector:latest
+    ghcr.io/sbogomolov/reflector:0.7
 ```
 
 To use a config file instead of (or alongside) the environment, mount it and pass its path as the argument. This form also shows running it as a service — `-d` with a restart policy:
@@ -175,7 +175,7 @@ docker run -d --name reflector --restart unless-stopped \
     --network host \
     --cap-drop ALL --cap-add NET_RAW \
     -v /path/to/config.toml:/etc/reflector/config.toml:ro \
-    ghcr.io/sbogomolov/reflector:latest /etc/reflector/config.toml
+    ghcr.io/sbogomolov/reflector:0.7 /etc/reflector/config.toml
 ```
 
 Logs are timestamped in UTC by default; pass `-e TZ=Europe/Berlin` (any zoneinfo name) for local time — the zoneinfo database is bundled in the image.

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -106,33 +106,32 @@ fi
 
 version=$("$(dirname "$0")/version.sh")
 
+# No "latest" tag anywhere: it tracks the Rust implementation; this repo builds version tags
+# on the 0.7.x line only.
 if [ "$push" = true ]; then
     docker buildx build \
         --platform "$platforms" \
         --push \
         -t "${image}:${version}" \
-        -t "${image}:latest" \
         .
 
-    printf '\nPublished %s:%s (also tagged latest).\n' "$image" "$version"
+    printf '\nPublished %s:%s.\n' "$image" "$version"
     printf 'Platforms: %s\n' "$platforms"
 elif [ "$platforms_set" = true ]; then
     docker buildx build \
         --load \
         --platform "$platforms" \
         -t "${image}:${version}" \
-        -t "${image}:latest" \
         .
 
-    printf '\nBuilt %s:%s for %s (also tagged latest).\n' "$image" "$version" "$platforms"
+    printf '\nBuilt %s:%s for %s.\n' "$image" "$version" "$platforms"
 else
     docker buildx build \
         --load \
         -t "${image}:${version}" \
-        -t "${image}:latest" \
         .
 
-    printf '\nBuilt %s:%s (also tagged latest).\n' "$image" "$version"
+    printf '\nBuilt %s:%s.\n' "$image" "$version"
 fi
 
 cat <<EOF


### PR DESCRIPTION
The C++ and Rust implementations share one image line (`ghcr.io/sbogomolov/reflector`; tags `< 0.8.0` are C++, `>= 0.8.0` Rust). Two problems with this repo's publishing:

- The release workflow named the image via `github.repository`, so the repo's rename to reflector-cpp silently changed the publish target. The image is now named `ghcr.io/<owner>/reflector` explicitly (build digest push, metadata, manifest, inspect). The `gh api` calls keep `github.repository` — that's the repo, not the image.
- Releases (and `docker_build.sh --push`, the manual path) tagged `latest`, which would clobber the Rust images' `latest` with a 0.7.x build. Version tags only now, everywhere; `docker_build.sh` drops `latest` from local builds too, and nothing in the repo consumed `reflector:latest`.

README follows: the `docker run` examples pull `:0.7` (the moving minor tag the workflow already produces) and the tag documentation notes that `latest` tracks the Rust implementation.

Verified: workflow YAML parses, `sh -n` on docker_build.sh, no remaining `latest` tag usage outside the explanatory comments.