### PR TITLE
docs: drop the stale reflector-rs name from the README notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 > [!IMPORTANT]
 > **This project has been rewritten in Rust.**
-> [**reflector-rs**](https://github.com/sbogomolov/reflector) reached full feature parity and is now where
-> all development happens — by the time you read this it may well have features this C++ version lacks. This
-> implementation still works and remains available, but new deployments should prefer reflector-rs.
+> [The Rust reflector](https://github.com/sbogomolov/reflector) reached full feature parity and is now
+> where all development happens — by the time you read this it may well have features this C++ version
+> lacks. This implementation still works and remains available, but new deployments should prefer the
+> Rust one.
 >
 > Image tags below `0.8.0` are this C++ version; `0.8.0` and later are the Rust rewrite.
 


### PR DESCRIPTION
The Rust rewrite was published under the original `reflector` name; "reflector-rs" never existed. The notice's link already pointed at the right repo — only the label was wrong. No other references in the repo (the `reflector-rss-` prefix in the valgrind soak script is RSS-the-metric, not a repo name).