### PR TITLE
ci: disable metadata-action's implicit latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,12 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/reflector
-          # Deliberately no "latest": that tag belongs to the Rust images; this repo releases
-          # version tags on the 0.7.x line only.
+          # No "latest": that tag belongs to the Rust images; this repo releases version tags on
+          # the 0.7.x line only. Omitting it from `tags` is not enough — the default flavor is
+          # latest=auto, which adds it on every semver release tag (how 0.7.3 clobbered the Rust
+          # latest) — so it must be disabled explicitly.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Removing `latest` from the tags list (562f43a) wasn't enough: `docker/metadata-action` defaults to the `latest=auto` flavor, which adds the tag on every semver release tag — so the v0.7.3 release still clobbered the Rust images' `latest`. It has been repointed to 0.11.0 by hand (`docker buildx imagetools create --tag ...:latest ...:0.11.0`, digests verified); this makes the workflow stop doing it: `flavor: latest=false`.