### PR TITLE
fix: zero sin6_scope_id where no kernel consults it

### DIFF
--- a/src/reflector/ip_address.cpp
+++ b/src/reflector/ip_address.cpp
@@ -165,6 +165,25 @@ std::optional<IpAddress> IpAddress::FromSockaddr(const sockaddr* address) noexce
     return std::nullopt;
 }
 
+namespace {
+
+// Whether the kernel consults sin6_scope_id for this address: link-local unicast, or multicast
+// scoped to the interface (ff?1::) or link (ff?2::). For everything else, including site-scoped
+// multicast, Linux ignores the field, macOS zeroes it before its lookup, and FreeBSD rejects a
+// bind that carries it (its lookup compares the whole sockaddr -> EADDRNOTAVAIL).
+bool NeedsScopeId(const IpAddress& address) noexcept {
+    if (address.IsLinkLocal()) {
+        return true;
+    }
+    if (!address.IsMulticast()) {
+        return false;
+    }
+    const auto scope = std::to_integer<uint8_t>(address.Bytes()[1]) & 0x0f;
+    return scope == 0x01 || scope == 0x02;
+}
+
+} // namespace
+
 socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsigned scope_id) const noexcept {
     std::memset(&storage, 0, sizeof(storage));
 
@@ -187,7 +206,7 @@ socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsign
         auto* v6 = reinterpret_cast<sockaddr_in6*>(&storage);
         v6->sin6_family = AF_INET6;
         v6->sin6_port = htons(port);
-        v6->sin6_scope_id = scope_id;
+        v6->sin6_scope_id = NeedsScopeId(*this) ? scope_id : 0;
         std::memcpy(&v6->sin6_addr, bytes_.data(), sizeof(v6->sin6_addr));
 #if !defined(__linux__)
         v6->sin6_len = sizeof(sockaddr_in6);

--- a/src/reflector/ip_address.h
+++ b/src/reflector/ip_address.h
@@ -84,7 +84,10 @@ public:
 
     // Fills `storage` and returns its used length (for bind/sendto's addrlen). The length may be
     // ignored when it's implied by context — e.g. a fixed-size group_req — so this is not
-    // [[nodiscard]]. `scope_id` populates sin6_scope_id for IPv6; ignored for IPv4.
+    // [[nodiscard]]. `scope_id` (an interface index) goes into sin6_scope_id only for addresses
+    // whose zone the kernel consults (link-local unicast, interface-/link-scoped multicast) and is
+    // zeroed otherwise — FreeBSD rejects a bind carrying it on any other address — so callers can
+    // pass their interface index unconditionally. Ignored for IPv4.
     socklen_t ToSockaddr(sockaddr_storage& storage, uint16_t port, unsigned scope_id = 0) const noexcept;
 
     [[nodiscard]] std::string ToString() const;

--- a/tests/ip_address_test.cpp
+++ b/tests/ip_address_test.cpp
@@ -283,6 +283,33 @@ TEST(IpAddressTest, ToSockaddrV6RoundTripsWithScopeId) {
 #endif
 }
 
+namespace {
+
+// The scope id ToSockaddr wrote for `address` when the caller passes 7 — the
+// kernel-consults-the-zone gate under test. A failed parse fails the test via Parse and lands on
+// its AnyV6 fallback, so no disengaged optional is ever dereferenced.
+uint32_t ScopeWrittenFor(const char* address) {
+    sockaddr_storage storage{};
+    Parse(address).ToSockaddr(storage, /*port=*/0, /*scope_id=*/7);
+    return reinterpret_cast<const sockaddr_in6*>(&storage)->sin6_scope_id;
+}
+
+} // namespace
+
+TEST(IpAddressTest, ToSockaddrKeepsTheScopeIdWhereTheKernelConsultsIt) {
+    EXPECT_EQ(ScopeWrittenFor("fe80::1"), 7u);   // link-local unicast: required to disambiguate
+    EXPECT_EQ(ScopeWrittenFor("ff02::fb"), 7u);  // link-scoped multicast
+    EXPECT_EQ(ScopeWrittenFor("ff01::1"), 7u);   // interface-scoped multicast
+}
+
+TEST(IpAddressTest, ToSockaddrZeroesTheScopeIdWhereTheKernelIgnoresIt) {
+    // FreeBSD rejects a bind carrying a zone on any of these (EADDRNOTAVAIL); Linux/macOS ignore it.
+    EXPECT_EQ(ScopeWrittenFor("2001:db8::1"), 0u);  // global unicast
+    EXPECT_EQ(ScopeWrittenFor("fd00::1"), 0u);      // unique-local
+    EXPECT_EQ(ScopeWrittenFor("ff05::c"), 0u);      // site-scoped multicast
+    EXPECT_EQ(ScopeWrittenFor("::1"), 0u);          // loopback
+}
+
 TEST(IpAddressTest, FromSockaddrUnknownFamilyReturnsNullopt) {
     sockaddr_storage storage{};
     storage.ss_family = AF_UNSPEC;

--- a/tests/port_reservation_test.cpp
+++ b/tests/port_reservation_test.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cerrno>
 #include <cstddef>
+#include <limits>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -78,6 +79,16 @@ TEST(PortReservationTest, MoveTransfersOwnershipWithoutDoubleClose) {
     PortReservation moved = std::move(*first);
     EXPECT_EQ(moved.Port(), port);
     // No crash / ASan double-close when both `first` (moved-from) and `moved` destruct here.
+}
+
+TEST(PortReservationTest, RoutableV6ReservationIgnoresTheInterfaceIndex) {
+    // Callers pass their interface index unconditionally; ToSockaddr must drop it for a
+    // non-link-local bind or FreeBSD fails the reservation with EADDRNOTAVAIL (::1 is
+    // non-link-local, and no interface has the bogus index).
+    const auto reservation =
+        PortReservation::Create(IpAddress::LoopbackV6(), std::numeric_limits<unsigned>::max());
+    ASSERT_TRUE(reservation.has_value());
+    EXPECT_NE(reservation->Port(), 0);
 }
 
 TEST(PortReservationTest, CreateWorksForIpv6) {


### PR DESCRIPTION
`ToSockaddr` wrote the caller's `scope_id` into every v6 sockaddr. A zone belongs only to link-local unicast and interface-/link-scoped multicast — the rule all three kernels share: FreeBSD rejects binds carrying it elsewhere (its ifa lookup compares the whole sockaddr → `EADDRNOTAVAIL`), Linux and macOS ignore it. Since #36 made site-scoped SSDP sessions bind a routable source, every `ff05::c` session on FreeBSD died at its reply-port reservation; the DIAL proxy's v6 source bind (`tcp_socket.cpp`) carried the same latent failure.

The gate lives inside `ToSockaddr` (`NeedsScopeId`: link-local unicast, or multicast with scope nibble 1/2); callers keep passing their interface index unconditionally, and both affected call sites — plus any future ones — are covered by the single change.

Tests: scope kept for `fe80::1`/`ff02::fb`/`ff01::1`, zeroed for GUA/ULA/`ff05::c`/`::1` (fails without the fix), plus `RoutableV6ReservationIgnoresTheInterfaceIndex` binding `::1` with a bogus index — the FreeBSD contract, pinned on every platform.

Full gate green: native unit (ASan/UBSan) 834/834, docker debug/release 826/826, docker valgrind 0 errors, e2e 33/33 plain and under valgrind.