### PR TITLE
fix: harden the DIAL proxy framer and key SSDP sessions by group

### DIFF
--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -97,6 +97,13 @@ bool HttpFraming::ScanAndRewriteHeader() {
     // branches. Requests carry no status code, so this stays false for them.
     const bool bodyless_status = type_ == MessageType::Response
         && StatusForbidsBody(ParseStatusCode(std::string_view{header_}.substr(0, header_.find(CRLF))));
+    // A HEAD response carries no body yet may still send Content-Length, indistinguishable from a
+    // real body without correlating the request method across the two framers: refuse HEAD at the
+    // request side instead. DIAL clients never issue it.
+    if (type_ == MessageType::Request && std::string_view{header_}.starts_with("HEAD ")) {
+        GetLogger().Error("refusing a HEAD request: its response cannot be framed");
+        return false;
+    }
     size_t pos = 0;
     while (pos < header_.size()) {
         const std::string_view header_view{header_};

--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -106,7 +106,8 @@ bool HttpFraming::ScanAndRewriteHeader() {
 
         if (StartsWithNoCase(line, "Content-Length:")) {
             const std::string_view v = TrimLeadingSpace(line.substr(line.find(':') + 1));
-            const auto result = std::from_chars(v.data(), v.data() + v.size(), content_length);
+            size_t parsed = 0;
+            const auto result = std::from_chars(v.data(), v.data() + v.size(), parsed);
             // Require the whole value to be the number, like ParseAuthority's port parse: from_chars stops
             // at the first non-digit and reports success, so "12abc" would otherwise frame a body of 12 and
             // mis-parse the rest. Trailing OWS (RFC 7230 §3.2.4) is tolerated; any other trailing byte rejects.
@@ -114,6 +115,13 @@ bool HttpFraming::ScanAndRewriteHeader() {
                 GetLogger().Error("malformed Content-Length value \"{}\"", v);
                 return false;
             }
+            // A second, differing Content-Length is a request-smuggling vector (RFC 9112 §6.3): refuse
+            // the message rather than pick a winner. Identical repeats agree on the framing, so they pass.
+            if (has_content_length && parsed != content_length) {
+                GetLogger().Error("conflicting Content-Length values {} and {}", content_length, parsed);
+                return false;
+            }
+            content_length = parsed;
             has_content_length = true;
         } else if (StartsWithNoCase(line, "Transfer-Encoding:")) {
             const std::string_view v = line.substr(line.find(':') + 1);

--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -181,6 +181,13 @@ std::optional<HttpFraming::Output> HttpFraming::Feed(std::string_view input) {
             return Output{};  // incomplete header: nothing forwardable yet, read more and feed again
         }
         const size_t header_len = term + HEADER_TERMINATOR.size();
+        // The cap must not depend on TCP segmentation: a coalesced read could otherwise slip a
+        // header past it that a segmented one could not (the unterminated check above never fires
+        // when the terminator is already in the buffer).
+        if (header_len > MAX_HEADER_BYTES) {
+            GetLogger().Error("header block exceeds the {}-byte cap", MAX_HEADER_BYTES);
+            return std::nullopt;
+        }
         header_.assign(input.data(), header_len);  // copy only the header, to rewrite it
         if (!ScanAndRewriteHeader()) {             // rewrites header_ in place and sets the body phase
             return std::nullopt;

--- a/src/reflector/http_message.cpp
+++ b/src/reflector/http_message.cpp
@@ -55,7 +55,7 @@ std::optional<Authority> ParseAuthority(std::string_view value, bool bare) {
         }
         auth_start = SCHEME.size();
     }
-    size_t auth_end = value.find_first_of("/ \t\r", auth_start);
+    size_t auth_end = value.find_first_of("/?# \t\r", auth_start);  // path, query, or fragment ends it (RFC 3986)
     if (auth_end == std::string_view::npos) {
         auth_end = value.size();
     }

--- a/src/reflector/http_message.h
+++ b/src/reflector/http_message.h
@@ -41,9 +41,9 @@ struct Authority {
 // on EOF). Direction matters, so the framer is told its MessageType and reads the response status: a request
 // with neither framing header is bodyless (rule 6), and a 1xx/204/304 response is bodyless whatever headers
 // it carries (rule 1).
-// KNOWN LIMITATION: a response to a HEAD request is bodyless even with a Content-Length, but the framer can't
-// tell — that needs the paired request method, which lives in the opposite direction's framer. DIAL issues no
-// HEAD, so this does not arise; correlating the request method across the two framers is out of scope here.
+// A HEAD request is refused outright: its response is bodyless even with a Content-Length, but the framer
+// can't tell — that needs the paired request method, which lives in the opposite direction's framer. DIAL
+// issues no HEAD, so refusing (drop-and-close) is cheaper than correlating methods across the two framers.
 class HttpFraming {
 public:
     // Called once per rewritable authority header — Host (requests), Application-URL / Location

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -153,11 +153,12 @@ void SsdpReflector::OnSourcePacket(const Packet& packet) noexcept {
     }
     const auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds{mx} + SESSION_GRACE;
 
-    // One session per client (searcher ip:port): a retransmit reuses its session, a new client gets a
-    // fresh one (reserved port + response capture), built locally so a failed reflect rolls it back via
-    // RAII. Either way the search is reflected once, from the session's reserved port.
+    // One session per (client, group): a retransmit to the same group reuses its session, a new client —
+    // or the same client searching a different group (a different reply scope) — gets a fresh one
+    // (reserved port + response capture), built locally so a failed reflect rolls it back via RAII.
+    // Either way the search is reflected once, from the session's reserved port.
     const auto existing_session = std::ranges::find_if(sessions_, [&](const Session& session) {
-        return session.searcher == packet.header.source;
+        return session.searcher == packet.header.source && session.group == packet.header.dest.addr;
     });
     std::optional<Session> new_session;
     if (existing_session == sessions_.end()) {
@@ -223,6 +224,7 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
     }
     return Session{
         .searcher = packet.header.source,
+        .group = packet.header.dest.addr,
         .searcher_mac = packet.header.source_mac,
         .expiry = expiry,
         .reservation = std::move(*reservation),

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -49,10 +49,13 @@ private:
     static constexpr std::chrono::seconds EVICTION_INTERVAL{1};
 
     // One in-flight client discovery awaiting unicast 200 OK replies; a client's retransmits reuse it.
-    // The client is `searcher` (ip:port) and the reserved port is reservation.Port(), so no separate
-    // key is stored — sessions live in a small vector, found by linear scan. Move-only.
+    // Keyed by (searcher ip:port, group): one reflector spans every SSDP group, and each group's reply
+    // port is bound to a scope-matched source (link-local for ff02::c, routable for ff05::c), so one
+    // searcher's searches to two groups need separate sessions or the second scope's replies land on an
+    // unwatched address. Sessions live in a small vector, found by linear scan. Move-only.
     struct Session {
         IpEndpoint searcher;
+        IpAddress group;
         MacAddress searcher_mac;
         std::chrono::steady_clock::time_point expiry;
         PortReservation reservation;

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -394,6 +394,22 @@ TEST(HttpFramingMiscTest, RefusesOversizedHeaderBlock) {
     EXPECT_FALSE(d.ok);
 }
 
+TEST(HttpFramingMiscTest, RefusesOverCapHeaderEvenWhenTerminated) {
+    // The cap must not depend on TCP segmentation: a fully terminated header block past the cap,
+    // delivered in one read, is refused just like an unterminated one — otherwise a coalesced read
+    // could slip a header through that a byte-at-a-time one could not.
+    std::string message =
+        "HTTP/1.1 200 OK\r\n"
+        "X-Pad: ";
+    message.append(3 * 1024, 'a');
+    message.append("\r\n\r\n");  // terminated, but the block is over the cap
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(message);
+    EXPECT_FALSE(d.ok);
+}
+
 TEST(HttpFramingMiscTest, FramesTwoPipelinedKeepAliveMessages) {
     const std::string first =
         "HTTP/1.1 200 OK\r\n"

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -451,6 +451,18 @@ TEST(HttpFramingMiscTest, AllowsIdenticalDuplicateContentLength) {
     EXPECT_TRUE(d.out.ends_with("hi"));
 }
 
+TEST(HttpFramingMiscTest, RefusesHeadRequest) {
+    // A HEAD response is bodyless but may still carry Content-Length, which this framer would await
+    // as phantom body bytes and desync the keep-alive stream. Refuse HEAD at the request side.
+    HostRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Request);
+    Driver d{framing};
+    d.Read(
+        "HEAD / HTTP/1.1\r\n"
+        "Host: 192.168.1.2:40000\r\n\r\n");
+    EXPECT_FALSE(d.ok);
+}
+
 TEST(HttpFramingMiscTest, FramesTwoPipelinedKeepAliveMessages) {
     const std::string first =
         "HTTP/1.1 200 OK\r\n"

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -410,6 +410,33 @@ TEST(HttpFramingMiscTest, RefusesOverCapHeaderEvenWhenTerminated) {
     EXPECT_FALSE(d.ok);
 }
 
+TEST(HttpFramingMiscTest, RefusesConflictingContentLengths) {
+    // Two differing Content-Length headers are a request-smuggling vector (RFC 9112 6.3): refuse
+    // rather than pick a last-wins length that a downstream peer might frame differently.
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 0\r\n"
+        "Content-Length: 100\r\n\r\n");
+    EXPECT_FALSE(d.ok);
+}
+
+TEST(HttpFramingMiscTest, AllowsIdenticalDuplicateContentLength) {
+    // Identical repeats agree on the framing, so they are tolerated (only a conflict is fatal).
+    UrlRewrite rewrite;
+    HttpFraming framing(AsRewrite(rewrite), HttpFraming::MessageType::Response);
+    Driver d{framing};
+    d.Read(
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 2\r\n"
+        "Content-Length: 2\r\n\r\n"
+        "hi");
+    EXPECT_TRUE(d.ok);
+    EXPECT_TRUE(d.out.ends_with("hi"));
+}
+
 TEST(HttpFramingMiscTest, FramesTwoPipelinedKeepAliveMessages) {
     const std::string first =
         "HTTP/1.1 200 OK\r\n"

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -151,6 +151,20 @@ TEST(ParseAuthorityTest, RejectsNonHttpAndMalformed) {
     EXPECT_FALSE(ParseAuthority("not-an-ip:8008", /*bare=*/true).has_value());      // host is not an IPv4 literal
 }
 
+TEST(ParseAuthorityTest, TerminatesAuthorityAtQueryOrFragment) {
+    // A pathless URL with a query or fragment: the authority ends at '?'/'#' (RFC 3986), so the
+    // host:port still parses and rewrites instead of folding the query into the port field.
+    const auto query = ParseAuthority("http://10.1.3.80:8008?token=x", /*bare=*/false);
+    ASSERT_TRUE(query.has_value());
+    EXPECT_EQ(query->endpoint, Device(8008));
+    EXPECT_EQ(std::string_view{"http://10.1.3.80:8008?token=x"}.substr(query->offset, query->length),
+        "10.1.3.80:8008");
+
+    const auto fragment = ParseAuthority("http://10.1.3.80#frag", /*bare=*/false);
+    ASSERT_TRUE(fragment.has_value());
+    EXPECT_EQ(fragment->endpoint, Device(80));
+}
+
 TEST(ParseAuthorityTest, AcceptsCaseInsensitiveHttpScheme) {
     const std::string_view value = "HTTP://10.1.3.80:8008/dd.xml";  // the scheme is case-insensitive (RFC 3986)
     const auto a = ParseAuthority(value, /*bare=*/false);

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -772,6 +772,41 @@ TEST_F(SsdpReflectorTest, DistinctClientsEachGetTheirOwnSession) {
     EXPECT_NE(target.sent[0].src_port, target.sent[1].src_port);  // distinct reserved ports
 }
 
+TEST_F(SsdpReflectorTest, OneSearcherGetsASessionPerGroup) {
+    // One reflector spans both IPv6 groups; each group's reply port is bound to a scope-matched
+    // source (link-local for ff02::c, routable for ff05::c). A searcher hitting both groups must get
+    // two sessions, or the second group's replies land on the first's unwatched reserved address.
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv6)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+
+    const auto search = MakeSearch();
+    packet_dispatcher.Deliver(source, MakePacket(search, IpAddress::SsdpGroupV6LinkLocal()));
+    packet_dispatcher.Deliver(source, MakePacket(search, IpAddress::SsdpGroupV6SiteLocal()));
+
+    ASSERT_EQ(target.sent.size(), 2u);
+    EXPECT_EQ(RegistrationCount(), base + 2);                      // two sessions, not one reused
+    EXPECT_NE(target.sent[0].src_port, target.sent[1].src_port);  // each on its own reserved port
+    EXPECT_EQ(target.sent[0].dst_ip, IpAddress::SsdpGroupV6LinkLocal());
+    EXPECT_EQ(target.sent[1].dst_ip, IpAddress::SsdpGroupV6SiteLocal());
+}
+
+TEST_F(SsdpReflectorTest, SameSearcherAndGroupReusesOneSession) {
+    // The dedup key is (searcher, group): a retransmit to the *same* group is still one session, so
+    // the group half of the key doesn't split genuine retransmits.
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv6)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+
+    const auto search = MakeSearch();
+    for (int i = 0; i < 3; ++i) {
+        packet_dispatcher.Deliver(source, MakePacket(search, IpAddress::SsdpGroupV6SiteLocal()));
+    }
+
+    EXPECT_EQ(target.sent.size(), 3u);         // reflected every time
+    EXPECT_EQ(RegistrationCount(), base + 1);  // but one shared session
+}
+
 TEST_F(SsdpReflectorTest, LogsDefaultedMxAtInfoWhenSearchHasNoMx) {
     const ScopedMinLogLevel level{LogLevel::Info};
     SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};


### PR DESCRIPTION
Five independent correctness fixes in the DIAL proxy framer and the SSDP search-session table, one per commit:

1. **Header-block cap on terminated headers** — the cap fired only on an unterminated block, so a coalesced read could slip an over-cap header through that a segmented read would refuse. Check the completed block too.
2. **Conflicting duplicate `Content-Length`** — a second, differing value was silently last-wins; a downstream peer may frame it differently (request smuggling). Refuse per RFC 9112 §6.3; identical repeats still pass.
3. **Authority termination at `?`/`#`** — a pathless URL with a query (`http://host:port?x=y`) folded the query into the port, failed the parse, and skipped the rewrite, leaking the device address. Stop at `?`/`#` per RFC 3986.
4. **Refuse HEAD requests** — a HEAD response is bodyless yet may carry `Content-Length`, which the response framer would await as phantom bytes and desync the keep-alive stream. Refuse at the request framer; DIAL issues no HEAD.
5. **SSDP session key by `(searcher, group)`** — one reflector spans every group and each group's reply port binds a scope-matched source (link-local `ff02::c`, routable `ff05::c`), so a searcher hitting both scopes collided into one session and lost the second scope's replies.

Each fix has a red-without/green-with test. Full gate green: native unit (ASan/UBSan) 841/841, docker debug/release 830/830, docker valgrind 0 errors, e2e 33/33 plain and under valgrind.