### PR TITLE
fix: canonicalize reflector names and reject whitespace in interface names

### DIFF
--- a/src/reflector/config/config.cpp
+++ b/src/reflector/config/config.cpp
@@ -150,7 +150,7 @@ public:
 
 class TomlSource final : public ConfigSource {
 public:
-    TomlSource(std::string_view name, const toml::table& table) noexcept : name_{name}, table_{&table} {}
+    TomlSource(std::string name, const toml::table& table) : name_{std::move(name)}, table_{&table} {}
 
     [[nodiscard]] std::string_view Name() const override { return name_; }
 
@@ -182,7 +182,7 @@ public:
     }
 
 private:
-    std::string_view name_;
+    std::string name_;
     const toml::table* table_;
 };
 
@@ -265,6 +265,29 @@ private:
     EnvParams params_;
 };
 
+// The ASCII whitespace bytes, as std::isspace classifies them in the C locale.
+constexpr std::string_view ASCII_WHITESPACE = " \t\n\v\f\r";
+
+// A reflector name's canonical form: surrounding whitespace trimmed and ASCII-lowercased, so two
+// names differing only in case or padding are one identity — used both as the display name and as
+// the duplicate-detection key. Internal whitespace is kept (a name may read "living room"); an
+// all-whitespace name canonicalizes to empty and is rejected downstream as unnamed.
+std::string CanonicalizeName(std::string_view name) {
+    const size_t first = name.find_first_not_of(ASCII_WHITESPACE);
+    if (first == std::string_view::npos) {
+        return {};
+    }
+    const size_t last = name.find_last_not_of(ASCII_WHITESPACE);
+    return AsciiToLower(name.substr(first, last - first + 1));
+}
+
+// True if `s` holds any ASCII whitespace. An OS interface name never does, so a padded or spaced
+// one is a config mistake: it would miss the interface (a confusing capture error) and, being
+// unequal to the intended name, slip past the source_if == target_if check.
+bool ContainsWhitespace(std::string_view s) noexcept {
+    return s.find_first_of(ASCII_WHITESPACE) != std::string_view::npos;
+}
+
 // Reads one entry from any source and appends a reflector config for each protocol it enables. The
 // entry's shared fields (mac, source_if, target_if, address_family) flow to every enabled protocol;
 // for a real device the one mac is both the WoL target and the mDNS/SSDP frame source.
@@ -341,6 +364,12 @@ std::optional<Error> ReadEntry(const ConfigSource& source,
         }
     }
 
+    if (ContainsWhitespace(source_if)) {
+        return Error{"entry \"{}\" source_if must not contain whitespace: \"{}\"", name, source_if};
+    }
+    if (ContainsWhitespace(target_if)) {
+        return Error{"entry \"{}\" target_if must not contain whitespace: \"{}\"", name, target_if};
+    }
     if (!wol && !mdns && !ssdp) {
         return Error{"entry \"{}\" enables no protocol (set wol, mdns, or ssdp)", name};
     }
@@ -397,7 +426,7 @@ struct ConfigAccumulator {
     std::optional<Error> AddEntry(const ConfigSource& source) {
         const auto name = source.Name();
         if (std::ranges::find(entry_names, name) != entry_names.end()) {
-            return Error{"duplicate entry name \"{}\"", name};
+            return Error{"duplicate reflector name \"{}\" (names are compared case-insensitively and trimmed)", name};
         }
         entry_names.emplace_back(name);
         return ReadEntry(source, wol, mdns, ssdp);
@@ -430,7 +459,7 @@ std::optional<Error> ApplyToml(ConfigAccumulator& acc, std::string_view str) {
                 if (!entry_table) {
                     return Error{"reflector \"{}\" must be a table ([reflectors.{}])", entry_name, entry_name};
                 }
-                const TomlSource source{entry_name, *entry_table};
+                const TomlSource source{CanonicalizeName(entry_name), *entry_table};
                 if (auto error = acc.AddEntry(source)) {
                     return error;
                 }
@@ -535,7 +564,7 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
             name = it->second;
             params.erase(it);
         }
-        const EnvSource source{std::move(name), std::move(params)};
+        const EnvSource source{CanonicalizeName(name), std::move(params)};
         if (auto error = acc.AddEntry(source)) {
             return error;
         }

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -759,6 +759,74 @@ wol = true
 )").has_value());
 }
 
+TEST(ConfigTest, RejectsCaseFoldedDuplicateName) {
+    // "TV" and "tv" are distinct TOML keys, so the parser accepts both; they canonicalize to one
+    // name, so they must be rejected rather than silently become two reflectors sharing it.
+    EXPECT_FALSE(Config::FromString(R"(
+[reflectors.TV]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+
+[reflectors.tv]
+source_if = "eth2"
+target_if = "eth3"
+wol = true
+)").has_value());
+}
+
+TEST(ConfigTest, TrimsAndLowercasesReflectorName) {
+    // The display name is the canonical form: surrounding whitespace trimmed, ASCII-lowercased,
+    // internal spaces kept.
+    const auto config = Config::FromString(R"(
+[reflectors."  Living Room  "]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)");
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().front().name, "living room");
+}
+
+TEST(ConfigTest, RejectsWhitespaceInInterfaceName) {
+    // A padded interface name would miss the interface and slip past source_if == target_if.
+    for (const std::string_view name : {"eth0 ", " eth0", "e th0"}) {
+        const auto config = Config::FromString(std::format(R"(
+[reflectors.tv]
+source_if = "{}"
+target_if = "eth1"
+wol = true
+)", name));
+        EXPECT_FALSE(config.has_value()) << "source_if=\"" << name << "\" should be rejected";
+    }
+}
+
+TEST(ConfigTest, EnvNameIsTrimmedAndLowercased) {
+    const auto config = Config::Load(std::nullopt, Env({
+        {"REFLECTOR_TV_SOURCE_IF", "eth0"},
+        {"REFLECTOR_TV_TARGET_IF", "eth1"},
+        {"REFLECTOR_TV_WOL", "true"},
+        {"REFLECTOR_TV_NAME", "  Living Room  "},
+    }));
+    ASSERT_TRUE(config.has_value()) << config.error().Message();
+    EXPECT_EQ(config->WolConfigs().front().name, "living room");
+}
+
+TEST(ConfigTest, RejectsEnvTagFoldingWithFileName) {
+    // An env tag "TV" and a file key "tv" canonicalize equal: the env source is a duplicate of the
+    // file reflector, not a separate one.
+    EXPECT_FALSE(Config::Load(R"(
+[reflectors.tv]
+source_if = "eth0"
+target_if = "eth1"
+wol = true
+)", Env({
+        {"REFLECTOR_TV_SOURCE_IF", "eth2"},
+        {"REFLECTOR_TV_TARGET_IF", "eth3"},
+        {"REFLECTOR_TV_MDNS", "true"},
+    })).has_value());
+}
+
 TEST(ConfigTest, RejectsDuplicateMacSourceTargetTriple) {
     EXPECT_FALSE(Config::FromString(R"(
 [reflectors.a]


### PR DESCRIPTION
Two config-input hardening fixes:

- **Reject whitespace in `source_if`/`target_if`.** An OS interface name never contains whitespace, so a padded `"eth0 "` would miss the interface (a confusing capture error) and, being unequal to `"eth0"`, slip past the `source_if == target_if` check. `ReadEntry` now rejects any whitespace.
- **Canonicalize reflector names** — trim surrounding whitespace and ASCII-lowercase at every source (TOML key, env tag, env `NAME`), so the canonical form is both the display name and the duplicate-detection key. Two TOML keys folding equal (`[reflectors.TV]` + `[reflectors.tv]`) or an env tag folding onto a file name previously became separate reflectors sharing an identity; now they collide and are rejected. `CanonicalizeName` and `ContainsWhitespace` share one `ASCII_WHITESPACE` definition so they can't drift.

Behavior change to note: reflector names now render lowercased in logs (`[reflectors."Living Room"]` → `living room`). This is the deliberate consequence of making the canonical form the identity.

Tests: case-folded duplicate rejected, name trimmed+lowercased (file and env `NAME`), whitespace in `source_if` rejected (leading/trailing/internal), env tag folding onto a file name rejected. Each is red-without/green-with. Full gate green: native unit (ASan/UBSan) 846/846, docker debug/release 838/838, docker valgrind 0 errors, e2e 33/33 plain and under valgrind.