### PR TITLE
fix: drop netlink datagrams that aren't from the kernel

### DIFF
--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -4,6 +4,8 @@
 #include "logger.h"
 #include "platform.h"
 #include "util/fd_util.h"
+#include "util/narrow_cast.h"
+#include "util/start_lifetime_as.h"
 
 #include <algorithm>
 #include <array>
@@ -55,6 +57,25 @@ void AddUnique(std::vector<unsigned>& indices, unsigned index) {
 
 } // namespace
 
+namespace detail {
+
+#if defined(__linux__)
+bool NetlinkSenderIsKernel(sockaddr_storage src, socklen_t len) noexcept {
+    if (len < narrow_cast<socklen_t>(sizeof(sockaddr_nl))) {
+        return false;  // too short to carry a netlink source address
+    }
+    // The kernel filled `src`'s bytes; bless them as the sockaddr_nl they represent (by value, since
+    // start_lifetime_as reuses the storage) rather than read a never-created object via a cast.
+    return start_lifetime_as<sockaddr_nl>(&src)->nl_pid == 0;
+}
+#else
+bool NetlinkSenderIsKernel(sockaddr_storage /*src*/, socklen_t /*len*/) noexcept {
+    return true;  // PF_ROUTE messages carry no per-message sender identity; all are the kernel's
+}
+#endif
+
+} // namespace detail
+
 DefaultAddressMonitor::DefaultAddressMonitor(Dispatcher& dispatcher)
         : dispatcher_{&dispatcher} {
     if (!Open()) {
@@ -62,11 +83,11 @@ DefaultAddressMonitor::DefaultAddressMonitor(Dispatcher& dispatcher)
     }
 }
 
-DefaultAddressMonitor::DefaultAddressMonitor(Dispatcher& dispatcher, int fd) noexcept
-        : dispatcher_{&dispatcher}, fd_{fd} {}
+DefaultAddressMonitor::DefaultAddressMonitor(Dispatcher& dispatcher, int fd, bool verify_sender) noexcept
+        : dispatcher_{&dispatcher}, fd_{fd}, verify_sender_{verify_sender} {}
 
-DefaultAddressMonitor DefaultAddressMonitor::ForTesting(Dispatcher& dispatcher, int fd) {
-    return DefaultAddressMonitor{dispatcher, fd};
+DefaultAddressMonitor DefaultAddressMonitor::ForTesting(Dispatcher& dispatcher, int fd, bool verify_sender) {
+    return DefaultAddressMonitor{dispatcher, fd, verify_sender};
 }
 
 bool DefaultAddressMonitor::Start(const OnInterfaceChanged& on_change) noexcept {
@@ -164,7 +185,10 @@ void DefaultAddressMonitor::OnReadable(int /*fd*/) noexcept {
     std::vector<unsigned> changed;
     bool overflowed = false;
     while (true) {
-        const auto received = recv(fd_.Get(), buffer.data(), buffer.size(), 0);
+        sockaddr_storage src{};
+        socklen_t addrlen = sizeof(src);
+        const auto received = recvfrom(fd_.Get(), buffer.data(), buffer.size(), 0,
+            reinterpret_cast<sockaddr*>(&src), &addrlen);
         if (received < 0) {
             if (IsWouldBlockErrno(errno)) {
                 break;  // drained
@@ -182,6 +206,12 @@ void DefaultAddressMonitor::OnReadable(int /*fd*/) noexcept {
         }
         if (received == 0) {
             break;
+        }
+        // A local process can unicast a netlink datagram to this socket (user-to-user needs no
+        // privilege), spoofing an address change; drop anything whose source isn't the kernel.
+        if (verify_sender_ && !detail::NetlinkSenderIsKernel(src, addrlen)) {
+            GetLogger().Debug("Dropping an address notification from a non-kernel sender");
+            continue;
         }
         // Once overflowed we'll emit a single refresh-all, so keep draining the socket but stop
         // parsing — the collected list would only be discarded.

--- a/src/reflector/default_address_monitor.h
+++ b/src/reflector/default_address_monitor.h
@@ -8,8 +8,21 @@
 #include <cstddef>
 #include <span>
 #include <vector>
+#include <sys/socket.h>
 
 namespace reflector {
+
+namespace detail {
+
+// Whether a notification's source address (as recvfrom reports it) is the kernel's. On Linux the
+// kernel's netlink source has nl_pid == 0; a user process's carries its own port id, so a non-zero
+// pid — or a source too short to be a sockaddr_nl — is a locally-spoofed datagram (netlink
+// user-to-user unicast needs no privilege) and is rejected. On the BSDs the route socket carries no
+// per-message sender identity, so every datagram is the kernel's and this is always true. Exposed
+// for testing. Prefer verifying in the monitor over trusting the socket's group binding.
+[[nodiscard]] bool NetlinkSenderIsKernel(sockaddr_storage src, socklen_t len) noexcept;
+
+} // namespace detail
 
 // Production AddressMonitor. Linux uses a NETLINK_ROUTE socket subscribed to the IPv4/IPv6 address
 // groups and the link group (a MAC change is a link event, not an address one); macOS uses a
@@ -24,8 +37,11 @@ public:
     // Test seam: build a monitor around an already-open `fd` (e.g. a socketpair end) instead of the
     // kernel notification socket. The monitor owns and closes `fd`. Like the production path, it
     // does not watch until Start() is called, so tests can drive OnReadable with synthesized
-    // messages and observe on_change with no real netlink/route socket.
-    [[nodiscard]] static DefaultAddressMonitor ForTesting(Dispatcher& dispatcher, int fd);
+    // messages and observe on_change with no real netlink/route socket. Sender verification is off
+    // by default: a socketpair source is not a netlink kernel address, so an on-check monitor would
+    // drop every synthesized datagram; pass `verify_sender=true` to exercise that drop path.
+    [[nodiscard]] static DefaultAddressMonitor ForTesting(Dispatcher& dispatcher, int fd,
+        bool verify_sender = false);
 
     [[nodiscard]] bool Start(const OnInterfaceChanged& on_change) noexcept override;
 
@@ -34,7 +50,7 @@ public:
 private:
     // Used by ForTesting: adopts an already-open `fd` instead of opening the kernel socket.
     // Watching begins at Start().
-    DefaultAddressMonitor(Dispatcher& dispatcher, int fd) noexcept;
+    DefaultAddressMonitor(Dispatcher& dispatcher, int fd, bool verify_sender) noexcept;
 
     // Opens the notification socket into fd_, leaving fd_ >= 0 on success. Logs the specific cause
     // and returns false on any failure; the caller then closes the fd.
@@ -63,6 +79,9 @@ private:
     OnInterfaceChanged on_change_;
     Dispatcher::Registration registration_;
     UniqueFd fd_;
+    // Whether OnReadable rejects datagrams whose source isn't the kernel (production always does;
+    // the testing seam defaults it off since a socketpair can't carry a netlink kernel source).
+    bool verify_sender_ = true;
 };
 
 } // namespace reflector

--- a/src/reflector/interface_address.cpp
+++ b/src/reflector/interface_address.cpp
@@ -153,10 +153,19 @@ bool NetlinkDump(int fd, uint16_t request_type, uint32_t seq, Handler&& handle) 
             buffer.resize(static_cast<size_t>(needed));
         }
 
-        const auto received = recv(fd, buffer.data(), buffer.size(), 0);
+        sockaddr_nl src{};
+        socklen_t addrlen = sizeof(src);
+        const auto received = recvfrom(fd, buffer.data(), buffer.size(), 0,
+            reinterpret_cast<sockaddr*>(&src), &addrlen);
         if (received < 0) {
             GetLogger().Error("Cannot read netlink dump reply: {}", Error::FromErrno());
             return false;
+        }
+        // Only the kernel (nl_pid 0) may answer the dump; a local process could unicast a spoofed
+        // reply to inject a bogus address. Discard anything else and read the next datagram.
+        if (addrlen < sizeof(src) || src.nl_pid != 0) {
+            GetLogger().Debug("Ignoring a netlink dump reply from a non-kernel sender (pid {})", src.nl_pid);
+            continue;
         }
 
         auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());

--- a/src/reflector/util/start_lifetime_as.h
+++ b/src/reflector/util/start_lifetime_as.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <version>
+
+namespace reflector {
+
+// Begins the lifetime of a T in the storage at `p`, preserving the bytes already there (e.g. a struct
+// the kernel filled via recvfrom) and returning a pointer to it — so reading through that pointer is
+// well-defined, unlike a reinterpret_cast, which reads an object that was never created there.
+//
+// Delegates to C++23 std::start_lifetime_as where the standard library ships it; until then
+// (libstdc++ < 15, the project's AppleClang) it falls back to the canonical memmove + launder form:
+// memmove implicitly creates the implicit-lifetime object (P0593) and the self-copy keeps the bytes.
+// is_trivially_copyable_v is the exact precondition — it implies implicit-lifetime (so std accepts it
+// too) and is precisely what memmove can reconstitute.
+template <typename T>
+    requires std::is_trivially_copyable_v<T>
+[[nodiscard]] T* start_lifetime_as(void* p) noexcept {
+#ifdef __cpp_lib_start_lifetime_as
+    return std::start_lifetime_as<T>(p);
+#else
+    return std::launder(static_cast<T*>(std::memmove(p, p, sizeof(T))));
+#endif
+}
+
+} // namespace reflector

--- a/tests/default_address_monitor_test.cpp
+++ b/tests/default_address_monitor_test.cpp
@@ -136,14 +136,15 @@ protected:
 
     // Builds a monitor adopting one end of a fresh non-blocking socketpair; the other end is kept
     // for feeding notifications. The monitor owns and closes its (read) end. Like production, it
-    // does not watch until StartWatching() — call that to begin observing.
-    DefaultAddressMonitor MakeMonitor() {
+    // does not watch until StartWatching() — call that to begin observing. Sender verification is
+    // off by default (a socketpair carries no netlink kernel source); pass true to drive that path.
+    DefaultAddressMonitor MakeMonitor(bool verify_sender = false) {
         int fds[2];
         EXPECT_EQ(::socketpair(AF_UNIX, SOCK_DGRAM, 0, fds), 0) << std::strerror(errno);
         EXPECT_EQ(::fcntl(fds[0], F_SETFL, O_NONBLOCK), 0) << std::strerror(errno);
         monitor_fd = fds[0];
         write_fd = fds[1];
-        return DefaultAddressMonitor::ForTesting(dispatcher, fds[0]);
+        return DefaultAddressMonitor::ForTesting(dispatcher, fds[0], verify_sender);
     }
 
     // Starts the monitor, binding the recording sink — the construct-then-Start() flow production
@@ -295,6 +296,24 @@ TEST_F(DefaultAddressMonitorTest, NeverForwardsIndexZero) {
     EXPECT_EQ(sink.changed, (std::vector<unsigned>{6}));
 }
 
+#if defined(__linux__)
+TEST_F(DefaultAddressMonitorTest, DropsNotificationsFromANonKernelSender) {
+    // With sender verification on, a datagram whose source isn't the kernel is dropped. The
+    // socketpair source is a plain AF_UNIX peer, not a netlink kernel address, so a well-formed
+    // message written to it must not be parsed. (macOS route sockets carry no sender identity, so
+    // this gate is a no-op there — Linux only.)
+    auto monitor = MakeMonitor(/*verify_sender=*/true);
+    ASSERT_TRUE(StartWatching(monitor));
+    std::vector<std::byte> messages;
+    AppendAddrMessage(messages, ADDR_MESSAGE, 7);
+
+    Write(messages);
+    FireReadable();
+
+    EXPECT_TRUE(sink.changed.empty());
+}
+#endif
+
 TEST_F(DefaultAddressMonitorTest, IgnoresSpuriousWakeWithNoData) {
     auto monitor = MakeMonitor();
     ASSERT_TRUE(StartWatching(monitor));
@@ -328,6 +347,30 @@ TEST_F(DefaultAddressMonitorTest, StartRejectsUnboundCallback) {
     EXPECT_FALSE(dispatcher.IsWatching(monitor_fd));
     EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
 }
+
+#if defined(__linux__)
+// A sockaddr_storage holding a sockaddr_nl with the given nl_pid, as recvfrom would report a
+// datagram's source. static for internal linkage (GCC's -Wmissing-declarations).
+static sockaddr_storage StorageWithPid(uint32_t pid) {
+    sockaddr_storage storage{};
+    auto* nl = reinterpret_cast<sockaddr_nl*>(&storage);
+    nl->nl_family = AF_NETLINK;
+    nl->nl_pid = pid;
+    return storage;
+}
+
+TEST(NetlinkSenderIsKernelTest, AcceptsOnlyTheKernel) {
+    const auto full = narrow_cast<socklen_t>(sizeof(sockaddr_nl));
+    EXPECT_TRUE(detail::NetlinkSenderIsKernel(StorageWithPid(0), full));      // the kernel (nl_pid 0)
+    EXPECT_FALSE(detail::NetlinkSenderIsKernel(StorageWithPid(1234), full));  // a user process's port id
+    EXPECT_FALSE(detail::NetlinkSenderIsKernel(StorageWithPid(0), 4));        // source too short
+}
+#else
+TEST(NetlinkSenderIsKernelTest, AcceptsEverythingOnTheBsds) {
+    // A PF_ROUTE message carries no per-message sender identity, so every datagram is the kernel's.
+    EXPECT_TRUE(detail::NetlinkSenderIsKernel(sockaddr_storage{}, 0));
+}
+#endif
 
 // The one genuinely-real test: opening the kernel notification socket and starting it on a real
 // dispatcher succeeds (needs no privilege on Linux/macOS).


### PR DESCRIPTION
Netlink user-to-user unicast needs no privilege, so a local process could send a datagram to the address-monitor socket (spoofing an address change) or unicast a spoofed dump reply to the resolver (injecting a bogus address/MAC). Both recv sites now read via `recvfrom` and require the source `nl_pid == 0`; anything else is dropped. macOS/FreeBSD route sockets carry no per-message sender identity, so every datagram there is the kernel's and the check is a no-op.

Defense-in-depth: exploiting this needs a local process able to send to the socket (CAP_NET_ADMIN for the multicast groups, or the socket's unicast port id), so it's low-severity hardening rather than a remote hole.

Also adds `reflector::start_lifetime_as<T>` (`util/start_lifetime_as.h`): a forward-compatible shim for C++23 `std::start_lifetime_as` — it delegates to the real one where the stdlib provides it (libstdc++ ≥ 15; not AppleClang or GCC 14 yet) and otherwise uses the canonical `memmove` + `launder` form, constrained on `is_trivially_copyable_v` (which implies implicit-lifetime and is exactly what `memmove` can reconstitute). The monitor reads the kernel-filled `sockaddr_storage` bytes as a `sockaddr_nl` through it, so the read is well-defined rather than a `reinterpret_cast` of an object that was never created there.

Tests: `NetlinkSenderIsKernel` accepts `nl_pid 0`, rejects a non-zero pid and a too-short source; a Linux drop-path case confirms a non-kernel datagram is not parsed. (The predicate's Linux logic is exercised on the docker/Linux lane — the socketpair-based harness can't emulate a kernel netlink source, so the test seam defaults sender-verification off and one case opts in.)

Full gate green: native unit (ASan/UBSan) 847/847, docker debug/release 840/840, docker valgrind 0 errors, e2e 33/33 plain and under valgrind.