### PR TITLE
ci: add an aggregate Success check and pin the workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: CI
 
+# No paths-ignore: a Markdown-only change must still run CI, else the `success` aggregate check
+# below never reports on it and branch protection blocks the merge.
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 permissions:
@@ -115,12 +113,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'
         run: |
-          sudo apt-get update
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
           sudo apt-get install -y --no-install-recommends \
             cmake \
             g++-14 \
@@ -197,7 +198,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       # FreeBSD shares its BSD platform path (kqueue, BPF, route sockets, getifaddrs) with macOS but needs
       # a real FreeBSD kernel to build and test — Docker can't provide one. vmactions boots a FreeBSD VM via
@@ -205,7 +206,7 @@ jobs:
       # script inside it. The VM runs as root, so the RequiresRoot tests (BPF capture, epair pairs) run
       # instead of skipping; each fixture self-skips where its operation isn't available.
       - name: Build and test in a FreeBSD VM
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@5a72679103d223925653750faa878a143340fbd0 # v1
         with:
           release: '14.2'  # 14.x base ships clang/libc++ >= 18 (std::println/format/expected); OPNsense 25.x tracks 14.3
           usesh: true
@@ -240,13 +241,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build reflector image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           tags: reflector:e2e
@@ -266,11 +267,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
           sudo apt-get install -y --no-install-recommends \
             cmake \
             g++-14 \
@@ -312,13 +316,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build runtime-valgrind image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           target: runtime-valgrind
@@ -331,3 +335,25 @@ jobs:
       # case and fail on any leak, leaked fd, or memcheck error. --skip-build reuses the image built above.
       - name: Run e2e under Valgrind memcheck
         run: python3 e2e/run.py --valgrind --skip-build
+
+  # A single aggregate status check: green only when every job above is green (or was legitimately skipped
+  # by `gate` because this tree already passed CI). Make THIS the sole required check in branch protection --
+  # then adding, renaming, or removing a job never means editing the required-checks list; its `needs` below
+  # is the one place that set is maintained. `if: !cancelled()` forces it to run even when upstream jobs were
+  # skipped (a skipped dependency would otherwise skip this job too); the failure step then treats only real
+  # failures / cancellations as fatal, so a gate-driven skip still passes.
+  success:
+    name: Success
+    if: ${{ !cancelled() }}
+    needs: [gate, unit, freebsd, docker-e2e, valgrind-unit, valgrind-e2e]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Report upstream results
+        run: |
+          echo "Upstream job results: ${{ join(needs.*.result, ', ') }}"
+      - name: Fail if any required job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more required jobs failed or were cancelled."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       # A version tag must match the project version in CMakeLists.txt, so the git tag, the published
       # image (docker_build.sh reads the same value), and the GitHub release name can never disagree.
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Verify tag matches CMakeLists version
         run: |
@@ -103,12 +103,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'
         run: |
-          sudo apt-get update
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
           sudo apt-get install -y --no-install-recommends \
             cmake g++-14 gcc-14 ninja-build ${{ matrix.cross_packages }}
 
@@ -149,7 +152,7 @@ jobs:
           cp build/reflector "dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reflector-${{ matrix.variant }}
           path: dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}
@@ -176,10 +179,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Build the static release binary in a FreeBSD VM
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@5a72679103d223925653750faa878a143340fbd0 # v1
         with:
           release: '14.2'
           arch: ${{ matrix.vm_arch }}
@@ -198,7 +201,7 @@ jobs:
             cp build/reflector "dist/reflector-${{ github.ref_name }}-freebsd-${{ matrix.arch }}"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reflector-freebsd-${{ matrix.arch }}
           path: dist/reflector-${{ github.ref_name }}-freebsd-${{ matrix.arch }}
@@ -235,13 +238,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -249,7 +252,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -265,7 +268,7 @@ jobs:
           touch "/tmp/digests/${DIGEST#sha256:}.digest"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -283,17 +286,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -301,7 +304,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/reflector
           # No "latest": that tag belongs to the Rust images; this repo releases version tags on
@@ -342,7 +345,7 @@ jobs:
 
     steps:
       - name: Download binary artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           pattern: reflector-*
@@ -354,7 +357,7 @@ jobs:
           sha256sum reflector-* | tee SHA256SUMS
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             dist/reflector-*


### PR DESCRIPTION
- **Aggregate `Success` check** — `needs:` every job, `if: !cancelled()` so it reports even when upstream jobs were skipped, and fails only on a real `failure`/`cancelled` result. Branch protection can require this one check; the `needs` list becomes the single place the required set is maintained. Gate-driven skips stay green (an already-validated tree legitimately skips the heavy jobs; on PRs the push-only `gate` shows as skipped, which is fine).
- **No more Markdown `paths-ignore`** — an md-only change must still run CI, else `Success` never reports on it and branch protection blocks the merge.
- **Action SHA pinning** — every `uses:` in ci.yml and release.yml pinned to the commit its tag resolves to (tags are mutable; a compromised action repo can repoint them). All 9 unique pins verified against the upstream tags; Renovate updates sha-pins and their `# vN` comments natively.
- **apt-flake tolerance** — `apt-get update || true` at the three runner-level sites: packages.microsoft.com flakes regularly, our packages come from the Ubuntu archive, and a genuinely broken archive still fails the install step loudly.

Workflow-only change; both files validate. This PR's own CI run is the live test — the `Success` job should appear below. Branch protection will be switched to require only `Success` after this lands.