### PR TITLE
refactor: hoist anonymous namespaces to file scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 ## Code style
 
 - Prefer RAII over manual cleanup.
+- Anonymous namespaces at file scope only, above `namespace reflector` (with `using namespace reflector;` inside when needed) — never nested inside it.
 - Pin Docker base images as `image:tag@sha256:digest` (don't drop the tag).
 - `auto`/`auto&`/`auto*` for locals and loop vars where the initializer makes the type clear; CTAD for aggregates (`std::array parts{a, b}`). Explicit type only when it genuinely clarifies (non-obvious conversion, pinning an interface).
 - Order struct members so padding lands at the end — place a trailing `bool` after a member with tail padding so it tucks in. A throwaway `static_assert(sizeof(X) == 0)` prints the actual size.

--- a/src/reflector/checksum.cpp
+++ b/src/reflector/checksum.cpp
@@ -7,9 +7,9 @@
 #include <cassert>
 #include <cstring>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 constexpr std::byte UDP_PROTOCOL{IP_PROTO_UDP};
 
@@ -37,6 +37,8 @@ uint16_t Fold(uint32_t sum) noexcept {
 }
 
 } // namespace
+
+namespace reflector {
 
 uint16_t Ipv4HeaderChecksum(std::span<const std::byte> header) noexcept {
     return Fold(Accumulate(header, 0));

--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -25,9 +25,9 @@
 #include <net/route.h>
 #endif
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 Logger& GetLogger() noexcept {
     static Logger logger{"AddressMonitor"};
@@ -56,6 +56,8 @@ void AddUnique(std::vector<unsigned>& indices, unsigned index) {
 }
 
 } // namespace
+
+namespace reflector {
 
 namespace detail {
 

--- a/src/reflector/frame_builder.cpp
+++ b/src/reflector/frame_builder.cpp
@@ -10,9 +10,9 @@
 #include <cstring>
 #include <sys/socket.h>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 // Shared L2/L3/L4 sizes/ethertypes/IP_PROTO_UDP come from protocol_constants.h. These are
 // frame-builder-only: the DLT_NULL prefix, the MAC length (from the canonical MacAddress type), a
@@ -90,6 +90,8 @@ void WriteIpUdp(const IpEndpoint& src, const IpEndpoint& dst,
 }
 
 } // namespace
+
+namespace reflector {
 
 MacAddress MulticastMacFor(const IpAddress& address) noexcept {
     const auto& bytes = address.Bytes();

--- a/src/reflector/interface_address.cpp
+++ b/src/reflector/interface_address.cpp
@@ -30,9 +30,9 @@
 #include <sys/ioctl.h>
 #endif
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 Logger& GetLogger() noexcept {
     static Logger logger{"InterfaceAddresses"};
@@ -79,20 +79,6 @@ void Consider(InterfaceAddresses& result, const IpAddress& address) noexcept {
         result.v6_routable = address;
     }
 }
-
-} // namespace
-
-namespace detail {
-
-void SelectSourceAddresses(std::span<const IpAddress> candidates, InterfaceAddresses& result) noexcept {
-    for (const auto& address : candidates) {
-        Consider(result, address);
-    }
-}
-
-} // namespace detail
-
-namespace {
 
 #if defined(__linux__)
 
@@ -372,6 +358,18 @@ void ResolveViaGetifaddrs(std::string_view interface, InterfaceAddresses& result
 #endif
 
 } // namespace
+
+namespace reflector {
+
+namespace detail {
+
+void SelectSourceAddresses(std::span<const IpAddress> candidates, InterfaceAddresses& result) noexcept {
+    for (const auto& address : candidates) {
+        Consider(result, address);
+    }
+}
+
+} // namespace detail
 
 #if defined(__linux__)
 

--- a/src/reflector/ip_address.cpp
+++ b/src/reflector/ip_address.cpp
@@ -11,21 +11,38 @@
 #include <ostream>
 #include <utility>
 
-namespace reflector {
-
-// IpAddress stores 16 network-order bytes; the platform address structs that ToSockaddr and
-// FromSockaddr memcpy to/from must fit within that (in_addr is 4 bytes, in6_addr 16).
-static_assert(sizeof(in_addr) <= sizeof(IpAddress::ByteArray));
-static_assert(sizeof(in6_addr) <= sizeof(IpAddress::ByteArray));
-
 namespace {
+
+using namespace reflector;
 
 Logger& GetLogger() noexcept {
     static Logger logger{"IpAddress"};
     return logger;
 }
 
+// Whether the kernel consults sin6_scope_id for this address: link-local unicast, or multicast
+// scoped to the interface (ff?1::) or link (ff?2::). For everything else, including site-scoped
+// multicast, Linux ignores the field, macOS zeroes it before its lookup, and FreeBSD rejects a
+// bind that carries it (its lookup compares the whole sockaddr -> EADDRNOTAVAIL).
+bool NeedsScopeId(const IpAddress& address) noexcept {
+    if (address.IsLinkLocal()) {
+        return true;
+    }
+    if (!address.IsMulticast()) {
+        return false;
+    }
+    const auto scope = std::to_integer<uint8_t>(address.Bytes()[1]) & 0x0f;
+    return scope == 0x01 || scope == 0x02;
+}
+
 } // namespace
+
+namespace reflector {
+
+// IpAddress stores 16 network-order bytes; the platform address structs that ToSockaddr and
+// FromSockaddr memcpy to/from must fit within that (in_addr is 4 bytes, in6_addr 16).
+static_assert(sizeof(in_addr) <= sizeof(IpAddress::ByteArray));
+static_assert(sizeof(in6_addr) <= sizeof(IpAddress::ByteArray));
 
 std::ostream& operator<<(std::ostream& os, IpAddress::Family family) {
     return os << std::format("{}", family);
@@ -164,25 +181,6 @@ std::optional<IpAddress> IpAddress::FromSockaddr(const sockaddr* address) noexce
         static_cast<int>(address->sa_family));
     return std::nullopt;
 }
-
-namespace {
-
-// Whether the kernel consults sin6_scope_id for this address: link-local unicast, or multicast
-// scoped to the interface (ff?1::) or link (ff?2::). For everything else, including site-scoped
-// multicast, Linux ignores the field, macOS zeroes it before its lookup, and FreeBSD rejects a
-// bind that carries it (its lookup compares the whole sockaddr -> EADDRNOTAVAIL).
-bool NeedsScopeId(const IpAddress& address) noexcept {
-    if (address.IsLinkLocal()) {
-        return true;
-    }
-    if (!address.IsMulticast()) {
-        return false;
-    }
-    const auto scope = std::to_integer<uint8_t>(address.Bytes()[1]) & 0x0f;
-    return scope == 0x01 || scope == 0x02;
-}
-
-} // namespace
 
 socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsigned scope_id) const noexcept {
     std::memset(&storage, 0, sizeof(storage));

--- a/src/reflector/mdns_message.cpp
+++ b/src/reflector/mdns_message.cpp
@@ -2,8 +2,6 @@
 
 #include <cstddef>
 
-namespace reflector {
-
 namespace {
 
 // DNS header (RFC 1035 §4.1.1): a fixed 12-byte prefix. The QR bit is the most significant bit of
@@ -13,6 +11,8 @@ constexpr size_t FLAGS_HIGH_OFFSET = 2;
 constexpr std::byte QR_BIT{0x80};
 
 } // namespace
+
+namespace reflector {
 
 std::optional<MdnsMessageKind> ClassifyMdnsMessage(std::span<const std::byte> payload) noexcept {
     if (payload.size() < DNS_HEADER_SIZE) {

--- a/src/reflector/mdns_reflector.cpp
+++ b/src/reflector/mdns_reflector.cpp
@@ -7,15 +7,17 @@
 #include <string>
 #include <utility>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 std::string LoggerName(const MdnsConfig& config) {
     return std::format("MdnsReflector:{}:{}->{}", config.name, config.source_if, config.target_if);
 }
 
 } // namespace
+
+namespace reflector {
 
 MdnsReflector::MdnsReflector(PacketDispatcher& packet_dispatcher, LinkSocket& source_socket,
     LinkSocket& target_socket, const MdnsConfig& config)

--- a/src/reflector/memory_report.cpp
+++ b/src/reflector/memory_report.cpp
@@ -18,9 +18,9 @@
 #endif
 #endif
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 Logger& GetLogger() noexcept {
     static Logger logger{"MemoryReport"};
@@ -233,6 +233,8 @@ void LogCgroupMemory() {
 #endif  // __linux__
 
 } // namespace
+
+namespace reflector {
 
 void LogMemoryReport() {
     const size_t peak = PeakRssKib();  // getrusage -- cross-platform high-water

--- a/src/reflector/port_reservation.cpp
+++ b/src/reflector/port_reservation.cpp
@@ -13,9 +13,9 @@
 #include <linux/filter.h>
 #endif
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 Logger& GetLogger() noexcept {
     static Logger logger{"PortReservation"};
@@ -23,6 +23,8 @@ Logger& GetLogger() noexcept {
 }
 
 } // namespace
+
+namespace reflector {
 
 std::optional<PortReservation> PortReservation::Create(const IpAddress& source_ip, unsigned scope_id) noexcept {
     const bool v6 = source_ip.IsV6();

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -46,9 +46,9 @@
 #include <sys/uio.h>
 #endif
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 // Classic BPF programs that accept IPv4 UDP or IPv6 UDP only (no VLAN tag, no IPv6
 // extension headers). Direction filtering keeps the kernel from feeding us our own injected
@@ -164,6 +164,8 @@ constexpr size_t LOOPBACK_FAMILY_SIZE = 4;
 // (shared with the frame builder). IPV4_HEADER_SIZE doubles as the minimum valid IPv4 header here.
 
 } // namespace
+
+namespace reflector {
 
 RawSocket::RawSocket(const Interface& interface)
         : logger_{std::format("RawSocket:{}", interface.Name())}

--- a/src/reflector/ssdp_message.cpp
+++ b/src/reflector/ssdp_message.cpp
@@ -13,9 +13,9 @@
 #include <string_view>
 #include <system_error>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 // True if `payload` begins with the ASCII bytes of `token`. Case-sensitive; a payload shorter than
 // the token never matches.
@@ -41,6 +41,8 @@ Logger& GetLogger() noexcept {
 }
 
 } // namespace
+
+namespace reflector {
 
 std::optional<SsdpMessageKind> ClassifySsdpMessage(std::span<const std::byte> payload) noexcept {
     if (StartsWith(payload, SEARCH_TOKEN)) {

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -12,15 +12,17 @@
 #include <string>
 #include <utility>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 std::string LoggerName(const SsdpConfig& config) {
     return std::format("SsdpReflector:{}:{}->{}", config.name, config.source_if, config.target_if);
 }
 
 } // namespace
+
+namespace reflector {
 
 SsdpReflector::SsdpReflector(PacketDispatcher& packet_dispatcher, LinkSocket& source_socket,
     LinkSocket& target_socket, const SsdpConfig& config)

--- a/src/reflector/wol_reflector.cpp
+++ b/src/reflector/wol_reflector.cpp
@@ -8,15 +8,17 @@
 #include <string>
 #include <utility>
 
-namespace reflector {
-
 namespace {
+
+using namespace reflector;
 
 std::string LoggerName(const WolConfig& config) {
     return std::format("WolReflector:{}:{}->{}", config.name, config.source_if, config.target_if);
 }
 
 } // namespace
+
+namespace reflector {
 
 WolReflector::WolReflector(PacketDispatcher& packet_dispatcher, LinkSocket& source_socket,
     LinkSocket& target_socket, const WolConfig& config)


### PR DESCRIPTION
Moves every anonymous namespace nested inside `namespace reflector` to file scope, above it — the shape `config.cpp` already used: one anon namespace per file with `using namespace reflector;` where the helpers need it (13 files, 15 blocks; `ip_address.cpp` and `interface_address.cpp` had two each, merged in original order). Platform `#if` guards and the netlink `#pragma GCC diagnostic` region stay wrapped around exactly the code they covered; named namespaces (`detail`) are untouched. Pure moves — no function bodies changed. The convention is now in CLAUDE.md's Code style section.

A scripted survey confirms zero nested anonymous namespaces remain in `src/`.

Full gate green: native unit (ASan/UBSan) 847/847, docker debug/release 840/840, docker valgrind 0 errors, e2e 33/33 plain and under valgrind.