### PR TITLE
fix: reject an M-SEARCH MX value with trailing garbage

### DIFF
--- a/src/reflector/ssdp_message.cpp
+++ b/src/reflector/ssdp_message.cpp
@@ -66,7 +66,13 @@ std::optional<uint8_t> ParseMSearchMx(std::span<const std::byte> payload) noexce
                 unsigned parsed = 0;
                 const auto* begin = value.data();
                 const auto* stop = value.data() + value.size();
-                if (std::from_chars(begin, stop, parsed).ec == std::errc{}) {
+                const auto result = std::from_chars(begin, stop, parsed);
+                // Require the whole value to be the integer the spec's grammar demands: from_chars
+                // stops at the first non-digit and reports success, so "2abc" would otherwise pass
+                // as 2. Trailing OWS is tolerated, like the DIAL framer's Content-Length parse; any
+                // other trailing byte makes the value invalid (the caller falls back to the default
+                // window and logs the searcher).
+                if (result.ec == std::errc{} && TrimLeadingSpace({result.ptr, stop}).empty()) {
                     return static_cast<uint8_t>(std::clamp<unsigned>(parsed, MX_MIN, MX_MAX));
                 }
             }

--- a/tests/ssdp_message_test.cpp
+++ b/tests/ssdp_message_test.cpp
@@ -92,6 +92,18 @@ TEST(SsdpMessageTest, ReturnsNulloptWhenMxAbsentOrUnparseable) {
     EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nMX: abc\r\n\r\n")), std::nullopt);
 }
 
+TEST(SsdpMessageTest, RejectsMxValueWithTrailingGarbage) {
+    // The MX grammar is a bare integer; "2abc" and "2 seconds" are invalid values, not a 2 —
+    // the whole value must be digits (trailing whitespace tolerated, next test).
+    EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nMX: 2abc\r\n\r\n")), std::nullopt);
+    EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nMX: 2 seconds\r\n\r\n")), std::nullopt);
+}
+
+TEST(SsdpMessageTest, ToleratesTrailingWhitespaceAfterMxValue) {
+    EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nMX: 2 \r\n\r\n")), 2);
+    EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nMX: 3\t\r\n\r\n")), 3);
+}
+
 TEST(SsdpMessageTest, ParsesMxHeaderNameCaseInsensitively) {
     EXPECT_EQ(ParseMSearchMx(Bytes("M-SEARCH * HTTP/1.1\r\nmx: 2\r\n\r\n")), 2);
 }


### PR DESCRIPTION
`ParseMSearchMx` checked `from_chars`'s error code but never its end pointer, so `"MX: 2abc"` quietly parsed as 2. The MX grammar is a bare integer (UDA also has devices silently discard malformed search requests outright): require the whole value to be digits, tolerating trailing whitespace like the DIAL framer's Content-Length parse.

Deliberate scope: a malformed value is rejected as a *value*, not as a message — the search still reflects, with the default window and the existing INFO log. That keeps malformed MX coherent with the existing missing-MX tolerance (the reflector reflects verbatim and lets target devices apply their own spec enforcement).

Tests: `"2abc"` / `"2 seconds"` rejected (fails without the fix), `"2 "` / `"3\t"` still parse (whitespace tolerance pinned).

Native unit (ASan/UBSan) 849/849 green locally; the full local gate is running in parallel with this PR's CI — I'll flag anything it turns up.