### PR TITLE
chore: align includes in platform-split files with the include policy

### DIFF
--- a/src/reflector/default_address_monitor.cpp
+++ b/src/reflector/default_address_monitor.cpp
@@ -14,14 +14,13 @@
 #include <cstring>
 #include <span>
 #include <vector>
+#include <net/if.h>
 #include <sys/socket.h>
-#include <unistd.h>
 
 #if defined(__linux__)
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #else
-#include <net/if.h>
 #include <net/route.h>
 #endif
 

--- a/src/reflector/event_loop_dispatcher.cpp
+++ b/src/reflector/event_loop_dispatcher.cpp
@@ -9,7 +9,6 @@
 #include <ctime>
 #include <utility>
 #include <vector>
-#include <unistd.h>
 
 #if defined(__linux__)
 #include <sys/epoll.h>

--- a/src/reflector/interface_address.cpp
+++ b/src/reflector/interface_address.cpp
@@ -13,7 +13,10 @@
 #include <string_view>
 #include <vector>
 
+#include <ifaddrs.h>
 #include <net/if.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -22,13 +25,9 @@
 #include <linux/if_link.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#include <cerrno>
 #else
-#include <ifaddrs.h>
 #include <net/if_dl.h>
-#include <netinet/in.h>
 #include <netinet6/in6_var.h>
-#include <sys/ioctl.h>
 #endif
 
 namespace {

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -27,13 +27,11 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <utility>
 
 #if defined(__linux__)
 #include <linux/filter.h>
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
-#include <sys/socket.h>
 // Added to the UAPI in Linux 4.20; define it for older build headers. At runtime the setsockopt may
 // still fail on a pre-4.20 kernel (or under user-mode QEMU), in which case Open falls back to dropping
 // our own outgoing frames inside the BPF filter (DROP_OUTGOING_PROLOGUE).
@@ -42,8 +40,6 @@
 #endif
 #else
 #include <net/bpf.h>
-#include <net/ethernet.h>
-#include <sys/uio.h>
 #endif
 
 namespace {

--- a/tests/default_address_monitor_test.cpp
+++ b/tests/default_address_monitor_test.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
+#include <net/if.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <vector>
@@ -21,7 +22,6 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #else
-#include <net/if.h>
 #include <net/route.h>
 #endif
 

--- a/tests/interface_address_test.cpp
+++ b/tests/interface_address_test.cpp
@@ -6,22 +6,20 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
-#include <vector>
-
-#if defined(__linux__)
-#include <net/if.h>
-#include <string>
-#else
-#include <array>
 #include <cstring>
 #include <span>
+#include <string>
 #include <string_view>
+#include <vector>
 #include <net/if.h>
+#include <sys/socket.h>
+
+#if !defined(__linux__)
 #include <net/if_dl.h>
 #include <netinet6/in6_var.h>
-#include <sys/socket.h>
 #endif
 
 namespace {

--- a/tests/util/udp_socket.cpp
+++ b/tests/util/udp_socket.cpp
@@ -4,13 +4,11 @@
 #include "reflector/util/fd_util.h"
 
 #include <cerrno>
-#include <cstring>
 #include <format>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <string>
 #include <sys/socket.h>
-#include <unistd.h>
 
 namespace reflector {
 


### PR DESCRIPTION
Align includes in the platform-split files with the include policy: portable headers are included unconditionally (the IDE's unused-include hint on the platform that doesn't use them is accepted); only headers that don't exist — or differ materially — across platforms stay behind `#if`.

An audit of every file with platform-conditional code found two kinds of drift:

- **Portable headers gated to one platform.** Moved back to the shared groups: `<net/if.h>` (duplicated in both branches of `interface_address_test`), `<ifaddrs.h>`, `<netinet/in.h>`, `<sys/ioctl.h>`, and the std headers in `interface_address_test`.
- **Dead includes** — no symbol used on any platform: `<unistd.h>` ×3 (fd lifecycle goes through `UniqueFd`, never raw `close()`), `<cerrno>` in the netlink block (errno is only read inside `Error::FromErrno`), `<utility>`, a duplicate `<sys/socket.h>`, and `<net/ethernet.h>` / `<sys/uio.h>` in the BPF block.

## Verification

- Native (macOS) build clean, unit suite green (Debug, ASan/UBSan).
- Docker/Linux build clean, unit suite green (Debug, ASan/UBSan).
- The `<net/ethernet.h>` / `<sys/uio.h>` removals sit in the `!linux` block; verified on macOS, with the FreeBSD lane as the backstop.
