### PR TITLE
fix: disable Nagle on the DIAL proxy's data sockets

### DIFF
--- a/src/reflector/tcp_socket.cpp
+++ b/src/reflector/tcp_socket.cpp
@@ -13,6 +13,7 @@
 #include <format>
 #include <utility>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -41,6 +42,17 @@ Logger& GetLogger() noexcept {
         return false;
     }
 #endif
+    return true;
+}
+
+// Disable Nagle on a data socket. Not for listeners: they carry no data, and the option doesn't
+// portably inherit across accept, so Accept sets it on each accepted fd instead.
+[[nodiscard]] bool SetNoDelay(int fd) noexcept {
+    const int on = 1;
+    if (::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) != 0) {
+        GetLogger().Error("Cannot set TCP_NODELAY: {}", Error::FromErrno());
+        return false;
+    }
     return true;
 }
 
@@ -198,7 +210,7 @@ std::optional<TcpSocket> TcpSocket::Connect(const IpEndpoint& dst, const Interfa
         return std::nullopt;
     }
     const unsigned scope_id = egress_if != nullptr ? egress_if->Index() : 0;
-    if (!ConfigureFd(fd) || (scope_id != 0 && !PinEgress(fd, af, *egress_if))) {
+    if (!ConfigureFd(fd) || !SetNoDelay(fd) || (scope_id != 0 && !PinEgress(fd, af, *egress_if))) {
         ::close(fd);
         return std::nullopt;
     }
@@ -250,6 +262,10 @@ std::optional<TcpSocket> TcpSocket::Accept() noexcept {
         return std::nullopt;
     }
 #endif
+    if (!SetNoDelay(client)) {  // SetNoDelay logged the cause
+        ::close(client);
+        return std::nullopt;
+    }
     // peer came from accept(); read the local endpoint once here (it matches the listener's bound address).
     auto local = LocalNameOf(client);
     if (!local) {

--- a/tests/tcp_socket_test.cpp
+++ b/tests/tcp_socket_test.cpp
@@ -19,6 +19,8 @@
 #include <vector>
 #include <fcntl.h>
 #include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <poll.h>
 #include <sys/socket.h>
 
@@ -106,6 +108,28 @@ protected:
 INSTANTIATE_TEST_SUITE_P(Families, TcpSocketFamilyTest,
     ::testing::Values(IpAddress::Family::V4, IpAddress::Family::V6),
     [](const auto& family_info) { return family_info.param == IpAddress::Family::V6 ? "V6" : "V4"; });
+
+// The accepted-socket check stands on its own: NODELAY inheritance across accept isn't portable.
+TEST_P(TcpSocketFamilyTest, DataSocketsGetNodelayTheListenerDoesNot) {
+    const auto nodelay = [](int fd) -> bool {
+        int value = -1;
+        socklen_t len = sizeof(value);
+        EXPECT_EQ(::getsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &value, &len), 0) << std::strerror(errno);
+        return value;
+    };
+
+    auto listener = TcpSocket::Listen(iface, GetParam());
+    ASSERT_TRUE(listener.has_value());
+    auto client = TcpSocket::Connect(listener->LocalEndpoint());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(WaitReadable(listener->Fd()));
+    auto server = listener->Accept();
+    ASSERT_TRUE(server.has_value());
+
+    EXPECT_TRUE(nodelay(client->Fd()));
+    EXPECT_TRUE(nodelay(server->Fd()));
+    EXPECT_FALSE(nodelay(listener->Fd()));  // carries no data — Nagle stays
+}
 
 TEST_P(TcpSocketFamilyTest, ListenAssignsAnEphemeralPort) {
     auto listener = TcpSocket::Listen(iface, GetParam());


### PR DESCRIPTION
TCP_NODELAY on outbound and accepted sockets, never the listener. Without it, a message that arrives split has its tail Nagle-held behind the first write's unacked bytes until the peer's delayed ACK — 40-100ms on a description fetch or launch POST.

Native (882) and docker/Linux (870) unit suites green; the new test reads the flag back per socket with the listener as control.