### PR TITLE
fix: refuse a mac filter on a target link that carries no MACs

### DIFF
--- a/src/reflector/link_socket.h
+++ b/src/reflector/link_socket.h
@@ -77,6 +77,10 @@ public:
     // interface outlives the socket.
     [[nodiscard]] virtual const Interface& GetInterface() const noexcept = 0;
 
+    // Whether frames on this link carry L2 MAC addresses. False on DLT_NULL links (BSD loopback),
+    // where a frame-source MAC filter can never match.
+    [[nodiscard]] virtual bool LinkCarriesMacs() const noexcept = 0;
+
 protected:
     // Mints a membership for `group` owned by this socket; the join must already have happened.
     [[nodiscard]] MulticastMembership MakeMembership(const IpAddress& group) noexcept {

--- a/src/reflector/mdns_reflector.cpp
+++ b/src/reflector/mdns_reflector.cpp
@@ -43,6 +43,11 @@ bool MdnsReflector::ValidateConfig(const MdnsConfig& config) {
 }
 
 void MdnsReflector::Initialize(const MdnsConfig& config) {
+    if (config.mac && !target_socket_->LinkCarriesMacs()) {
+        logger_.Error("Cannot create mdns reflector \"{}\": mac cannot match on \"{}\" (the link carries no MAC addresses)",
+            config.name, config.target_if);
+        return;
+    }
     // mDNS is bidirectional, so a handled family must be sendable on BOTH interfaces (capability_
     // tracks the AND): the target re-emits relayed queries, the source re-emits relayed responses.
     // A required family must already be reflectable; an optional one comes up later if it ever is.

--- a/src/reflector/raw_socket.h
+++ b/src/reflector/raw_socket.h
@@ -59,6 +59,14 @@ public:
 
     [[nodiscard]] const Interface& GetInterface() const noexcept override { return *interface_; }
 
+    [[nodiscard]] bool LinkCarriesMacs() const noexcept override {
+#if defined(__linux__)
+        return true;  // AF_PACKET delivers Ethernet framing everywhere, even on lo
+#else
+        return link_type_ == LinkType::Ethernet;
+#endif
+    }
+
     // Injects a UDP datagram out this interface as a raw L2 frame, building the Ethernet/IP/UDP
     // headers and checksums from the interface's cached source MAC/IP and writing the frame to the
     // kernel. These three differ only in the L2 destination: SendUdpDatagram takes an explicit

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -49,6 +49,11 @@ bool SsdpReflector::ValidateConfig(const SsdpConfig& config) {
 }
 
 void SsdpReflector::Initialize(const SsdpConfig& config) {
+    if (config.mac && !target_socket_->LinkCarriesMacs()) {
+        logger_.Error("Cannot create ssdp reflector \"{}\": mac cannot match on \"{}\" (the link carries no MAC addresses)",
+            config.name, config.target_if);
+        return;
+    }
     // SSDP is bidirectional, so a handled family must be sendable on BOTH interfaces (capability_
     // tracks the AND): the target re-emits reflected searches, the source re-emits advertisements.
     // A required family must already be reflectable; an optional one comes up later if it ever is.

--- a/tests/mdns_reflector_test.cpp
+++ b/tests/mdns_reflector_test.cpp
@@ -410,6 +410,29 @@ TEST_F(MdnsReflectorTest, FailureBringingUpSecondFamilyRollsBackTheFirst) {
     EXPECT_NE(std::ranges::find(source.left_groups, IpAddress::MdnsGroupV4()), source.left_groups.end());
 }
 
+TEST_F(MdnsReflectorTest, RejectsAMacFilterOnATargetLinkWithoutMacs) {
+    target.carries_macs = false;
+    auto config = MakeConfig(AddressFamily::IPv4);
+    config.mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");
+
+    const auto output = CaptureStdout([&] {
+        const MdnsReflector reflector{packet_dispatcher, source, target, config};
+        EXPECT_FALSE(reflector.IsValid());
+        EXPECT_EQ(RegistrationCount(), 0);
+    });
+    EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
+
+    // Same link without the filter is fine — only the source_mac match is impossible.
+    const MdnsReflector unfiltered{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    EXPECT_TRUE(unfiltered.IsValid());
+
+    // The filter reads target frames, so a MAC-less source link doesn't matter.
+    source.carries_macs = false;
+    target.carries_macs = true;
+    const MdnsReflector filtered{packet_dispatcher, source, target, config};
+    EXPECT_TRUE(filtered.IsValid());
+}
+
 TEST_F(MdnsReflectorTest, MacFilterRelaysOnlyTheConfiguredDevice) {
     auto config = MakeConfig(AddressFamily::IPv4);
     config.mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");

--- a/tests/mocks/fake_link_socket.h
+++ b/tests/mocks/fake_link_socket.h
@@ -76,7 +76,10 @@ struct FakeLinkSocket : LinkSocket {
 
     FakeInterface iface;  // the owned identity; ignored when `borrowed` is set
     const Interface* borrowed = nullptr;
+    [[nodiscard]] bool LinkCarriesMacs() const noexcept override { return carries_macs; }
+
     bool valid = true;
+    bool carries_macs = true;
     int fd = -1;
     bool fail_send = false;
     bool fail_join = false;

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -488,6 +488,29 @@ TEST_F(SsdpReflectorTest, DialProxySurvivesAFamilyTeardown) {
     EXPECT_NE(text.find("http://127.0.0.1:"), std::string_view::npos) << text;
 }
 
+TEST_F(SsdpReflectorTest, RejectsAMacFilterOnATargetLinkWithoutMacs) {
+    target.carries_macs = false;
+    auto config = MakeConfig(AddressFamily::IPv4);
+    config.mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");
+
+    const auto output = CaptureStdout([&] {
+        const SsdpReflector reflector{packet_dispatcher, source, target, config};
+        EXPECT_FALSE(reflector.IsValid());
+        EXPECT_EQ(RegistrationCount(), 0);
+    });
+    EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
+
+    // Same link without the filter is fine — only the source_mac match is impossible.
+    const SsdpReflector unfiltered{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    EXPECT_TRUE(unfiltered.IsValid());
+
+    // The filter reads target frames, so a MAC-less source link doesn't matter.
+    source.carries_macs = false;
+    target.carries_macs = true;
+    const SsdpReflector filtered{packet_dispatcher, source, target, config};
+    EXPECT_TRUE(filtered.IsValid());
+}
+
 TEST_F(SsdpReflectorTest, MacFilterReflectsOnlyTheConfiguredDevice) {
     auto config = MakeConfig(AddressFamily::IPv4);
     config.mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");

--- a/tests/wol_reflector_test.cpp
+++ b/tests/wol_reflector_test.cpp
@@ -194,6 +194,18 @@ protected:
     }
 };
 
+// WoL matches the MAC inside the magic packet's payload, not the frame's L2 source, so MAC-less
+// links take a mac filter that mdns/ssdp would refuse.
+TEST_F(WolReflectorTest, MacFilterIsFineOnLinksWithoutMacs) {
+    source.carries_macs = false;
+    target.carries_macs = false;
+    auto config = MakeConfig(IpAddress::Family::V4);
+    config.mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");
+
+    const auto reflector = BuildV4Reflector(config);
+    EXPECT_TRUE(reflector.IsValid());
+}
+
 TEST_F(WolReflectorTest, RejectsConfigWithEmptyPorts) {
     auto config = MakeConfig(IpAddress::Family::V4);
     config.ports = {};


### PR DESCRIPTION
mdns/ssdp filter on the frame's L2 source, which a DLT_NULL target link (BSD loopback) never carries — the entry silently reflected nothing. Creation now fails loudly via a new `LinkCarriesMacs()` seam on LinkSocket (Linux AF_PACKET framing always carries MACs, so this only fires on the BSDs). WoL is exempt: it matches the payload MAC.

Native (885) and docker/Linux (873) unit suites green; tests pin the rejection with rollback, the right-socket choice, the unfiltered control, and the WoL exemption on fully MAC-less links.