### PR TITLE
fix: reject an env parameter set twice instead of last-wins

### DIFF
--- a/src/reflector/config/config.cpp
+++ b/src/reflector/config/config.cpp
@@ -537,7 +537,14 @@ std::optional<Error> ApplyEnv(ConfigAccumulator& acc, std::span<const EnvVar> en
         if (param.empty()) {
             return Error{"environment variable \"{}\" is missing a parameter name after the tag", var.key};
         }
-        tags[std::string{tag}].insert_or_assign(AsciiToLower(param), std::string{var.value});
+        // Params fold case-insensitively, so REFLECTOR_TV_SOURCE_IF and REFLECTOR_TV_source_if land
+        // in the same slot.
+        const auto [it, inserted] =
+            tags[std::string{tag}].try_emplace(AsciiToLower(param), std::string{var.value});
+        if (!inserted) {
+            return Error{"environment variable \"{}\" sets \"{}\", which another variable already set (names are case-insensitive)",
+                var.key, it->first};
+        }
     }
 
     if (log_level_value) {

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -1758,6 +1758,22 @@ TEST(ConfigTest, EnvRejectsDuplicateNameAcrossTags) {
     EXPECT_FALSE(config.has_value());
 }
 
+TEST(ConfigTest, EnvRejectsAParamSetTwice) {
+    EXPECT_FALSE(Config::Load(std::nullopt, Env({
+        {"REFLECTOR_TV_SOURCE_IF", "eth0"},
+        {"REFLECTOR_TV_TARGET_IF", "eth1"},
+        {"REFLECTOR_TV_WOL", "true"},
+        {"REFLECTOR_TV_source_if", "eth2"},
+    })).has_value());
+
+    // The same set minus the duplicate is valid — the rejection above is the duplicate, not the shape.
+    EXPECT_TRUE(Config::Load(std::nullopt, Env({
+        {"REFLECTOR_TV_SOURCE_IF", "eth0"},
+        {"REFLECTOR_TV_TARGET_IF", "eth1"},
+        {"REFLECTOR_TV_WOL", "true"},
+    })).has_value());
+}
+
 TEST(ConfigTest, EnvRejectsTagsDifferingOnlyByCase) {
     // The tag map keys on the raw tag (case-sensitive), so TV and tv are two groups — but both
     // canonicalize to the reflector name "tv", so the second is rejected as a duplicate rather than


### PR DESCRIPTION
Write-once env param slots: a case-folded collision (REFLECTOR_TV_SOURCE_IF + REFLECTOR_TV_source_if) now errors naming the variable and parameter, instead of the later environ entry silently winning.

Native (886) and docker/Linux (874) unit suites green; test pins the rejection with the same set minus the duplicate as the accepted control.