### PR TITLE
fix: frame/payload ceilings, MX log level, framing comment corrections

### DIFF
--- a/src/reflector/dial_proxy.cpp
+++ b/src/reflector/dial_proxy.cpp
@@ -233,7 +233,7 @@ void DialProxy::Connection::Forward(
             Abort();
             return;
         }
-        if (out->consumed == 0) {  // incomplete header: keep the bytes, wait for the next edge
+        if (out->consumed == 0) {  // incomplete message: keep the bytes, wait for the next edge
             break;
         }
         // Close-don't-forward: a u2c Rest-listener mint failed inside Feed and Aborted us, so the header

--- a/src/reflector/http_message.h
+++ b/src/reflector/http_message.h
@@ -54,7 +54,8 @@ public:
     // The forwardable result of one Feed. `header` is the rewritten header block (a view into HttpFraming's
     // own scratch), empty while a body is still streaming across feeds. `body` is a slice of the fed input
     // (zero-copy), possibly empty. The owner forwards header then body together. `consumed` is how many fed
-    // bytes to drop; 0 means nothing was forwardable yet (an incomplete header) — read more and feed again.
+    // bytes to drop; 0 means nothing was forwardable yet — an incomplete header, or a chunk-size line
+    // split across reads — so read more and feed again.
     // Both views are valid until the next Feed (which reuses the scratch) or until the owner advances its
     // buffer past `consumed`.
     struct Output {

--- a/src/reflector/protocol_constants.h
+++ b/src/reflector/protocol_constants.h
@@ -25,4 +25,10 @@ inline constexpr uint8_t IP_PROTO_UDP = 17;
 // would be IP-fragmented and the parser drops fragments anyway.
 inline constexpr size_t MAX_FRAME_SIZE = 4 * 1024;
 
+// The largest UDP payload that still fits MAX_FRAME_SIZE once framed, under the worst-case header
+// stack (Ethernet over DLT_NULL's 4 bytes, IPv6 over IPv4, no extension headers since the builders
+// emit none): anything built within it is sendable on either family.
+inline constexpr size_t MAX_UDP_PAYLOAD_SIZE =
+    MAX_FRAME_SIZE - (ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE);
+
 } // namespace reflector

--- a/src/reflector/protocol_constants.h
+++ b/src/reflector/protocol_constants.h
@@ -20,4 +20,9 @@ inline constexpr uint16_t IPV4_ETHERTYPE = 0x0800;
 inline constexpr uint16_t IPV6_ETHERTYPE = 0x86dd;
 inline constexpr uint8_t IP_PROTO_UDP = 17;
 
+// Ceiling for any frame the reflector handles, capture and egress alike: one datagram at a typical
+// Ethernet MTU plus headers, with headroom. Reflected traffic fits well below it; larger datagrams
+// would be IP-fragmented and the parser drops fragments anyway.
+inline constexpr size_t MAX_FRAME_SIZE = 4 * 1024;
+
 } // namespace reflector

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -138,19 +138,6 @@ std::array<BpfInsn, 9> LOOPBACK_UDP_FILTER{{
 }};
 #endif
 
-// Sized for one frame at a typical Ethernet MTU plus headers. The reflected traffic
-// classes (WoL, mDNS, SSDP) all fit comfortably below this; oversized datagrams would
-// be IP-fragmented and our parser drops fragments anyway. Used by the Linux production
-// constructor and by the test-only ForTesting constructor on both platforms; macOS
-// production instead sizes the buffer from BPF's own preferred size via BIOCGBLEN.
-constexpr size_t DEFAULT_RECEIVE_BUFFER_SIZE = 4 * 1024;
-
-// The frame to send is assembled into a stack buffer this size. Same rationale as the receive
-// buffer: one datagram at a typical MTU plus headers, with headroom; the traffic we emit (WoL,
-// later mDNS/SSDP) stays well under it and we don't fragment. BuildUdpFrame fails cleanly if a
-// caller ever exceeds it.
-constexpr size_t SEND_BUFFER_SIZE = 4 * 1024;
-
 #if !defined(__linux__)
 // DLT_NULL framing: 4 bytes of address family in host byte order, then the IP packet.
 constexpr size_t LOOPBACK_FAMILY_SIZE = 4;
@@ -220,7 +207,7 @@ RawSocket::RawSocket(const Interface& interface)
         return;
     }
 
-    receive_buffer_.resize(DEFAULT_RECEIVE_BUFFER_SIZE);
+    receive_buffer_.resize(MAX_FRAME_SIZE);
 
     logger_.Debug("Opened AF_PACKET socket fd {} on interface", fd_.Get());
 
@@ -324,22 +311,20 @@ RawSocket::RawSocket(const Interface& interface)
 #endif
 }
 
-RawSocket::RawSocket(TestingTag, const Interface& interface, int owned_fd) noexcept
+RawSocket::RawSocket(TestingTag, const Interface& interface, int owned_fd,
+    size_t receive_buffer_size) noexcept
         : logger_{std::format("RawSocket:{}", interface.Name())}
         , interface_{&interface}
         , fd_{owned_fd} {
-    // Production sizes receive_buffer_ during setup (constant on Linux, BIOCGBLEN on macOS);
-    // tests skip that path, so use the same default the Linux production uses — enough for
-    // one full-MTU frame plus headers.
-    receive_buffer_.resize(DEFAULT_RECEIVE_BUFFER_SIZE);
+    receive_buffer_.resize(receive_buffer_size);
 }
 
-RawSocket RawSocket::ForTesting(const Interface& interface, int owned_fd) {
-    return RawSocket{TestingTag{}, interface, owned_fd};
+RawSocket RawSocket::ForTesting(const Interface& interface, int owned_fd, size_t receive_buffer_size) {
+    return RawSocket{TestingTag{}, interface, owned_fd, receive_buffer_size};
 }
 
 std::unique_ptr<RawSocket> RawSocket::ForTestingPtr(const Interface& interface, int owned_fd) {
-    return std::unique_ptr<RawSocket>(new RawSocket{TestingTag{}, interface, owned_fd});
+    return std::unique_ptr<RawSocket>(new RawSocket{TestingTag{}, interface, owned_fd, MAX_FRAME_SIZE});
 }
 
 RawSocket::~RawSocket() noexcept {
@@ -372,7 +357,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
         return false;
     }
 
-    std::array<std::byte, SEND_BUFFER_SIZE> frame{};
+    std::array<std::byte, MAX_FRAME_SIZE> frame{};
 #if defined(__linux__)
     const size_t length = BuildUdpFrame(dst_mac, interface_->Mac(), IpEndpoint{*source, src_port}, dst,
         payload, ttl, frame);
@@ -581,6 +566,15 @@ std::optional<Packet> RawSocket::Receive() noexcept {
     if (header.bh_datalen > header.bh_caplen) {
         logger_.Warning("Dropping oversized frame: {} bytes exceeds {}-byte receive buffer",
             header.bh_datalen, receive_buffer_.size());
+        return std::nullopt;
+    }
+
+    // Fully captured, but bigger than anything the send path can re-emit — the BIOCGBLEN-sized
+    // batch buffer admits frames the MAX_FRAME_SIZE-sized Linux scratch would have refused, so
+    // enforce the same ceiling here at capture.
+    if (header.bh_caplen > MAX_FRAME_SIZE) {
+        logger_.Warning("Dropping oversized frame: {} bytes exceeds the {}-byte frame ceiling",
+            header.bh_caplen, MAX_FRAME_SIZE);
         return std::nullopt;
     }
 

--- a/src/reflector/raw_socket.h
+++ b/src/reflector/raw_socket.h
@@ -5,6 +5,7 @@
 #include "logger.h"
 #include "packet.h"
 #include "platform.h"
+#include "protocol_constants.h"
 #include "util/address_family_pair.h"
 #include "util/no_move.h"
 #include "util/unique_fd.h"
@@ -47,8 +48,10 @@ public:
     // Receive() consumes bytes from that fd the same way the production socket would,
     // so tests can either synthesize Packets via DefaultPacketDispatcher::DispatchPacket directly
     // (when nothing is written to the fd) or drive real frames end-to-end via
-    // TestCaptureSocket::WriteFrame.
-    [[nodiscard]] static RawSocket ForTesting(const Interface& interface, int owned_fd);
+    // TestCaptureSocket::WriteFrame. `receive_buffer_size` mimics macOS production's
+    // BIOCGBLEN-sized batches when a test needs a buffer larger than one frame.
+    [[nodiscard]] static RawSocket ForTesting(const Interface& interface, int owned_fd,
+        size_t receive_buffer_size = MAX_FRAME_SIZE);
 
     // unique_ptr counterpart to ForTesting, for owners that hold the (immovable) socket
     // behind a pointer — e.g. Application's injectable capture-socket factory.
@@ -109,7 +112,7 @@ private:
     friend class RawSocketInterfacePairRequiresRootTest;  // inspects the membership refcounts + join fds
 
     enum class TestingTag {};
-    RawSocket(TestingTag, const Interface& interface, int owned_fd) noexcept;
+    RawSocket(TestingTag, const Interface& interface, int owned_fd, size_t receive_buffer_size) noexcept;
 
     void Close() noexcept;
 

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -154,8 +154,9 @@ void SsdpReflector::OnSourcePacket(const Packet& packet) noexcept {
     const auto parsed_mx = ParseMSearchMx(packet.payload);
     const uint8_t mx = parsed_mx.value_or(MSEARCH_MX_DEFAULT);
     if (!parsed_mx) {
-        // A multicast M-SEARCH must carry MX (UDA 2.0); surface the non-conformant searcher at INFO.
-        logger_.Info("M-SEARCH from {} has no/invalid MX; using the default {}s window",
+        // A multicast M-SEARCH must carry MX (UDA 2.0), but this fires on every search including
+        // retransmits — one non-conformant client would flood any louder level.
+        logger_.Debug("M-SEARCH from {} has no/invalid MX; using the default {}s window",
             packet.header.source, static_cast<unsigned>(mx));
     }
     const auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds{mx} + SESSION_GRACE;

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -2,6 +2,7 @@
 
 #include "interface.h"
 #include "port_reservation.h"
+#include "protocol_constants.h"
 #include "ssdp_message.h"
 #include "util/delegate.h"
 
@@ -248,9 +249,12 @@ void SsdpReflector::OnTargetPacket(const Packet& packet) noexcept {
     // A DIAL advertisement's LOCATION is first rewritten to a minted source_if listener (the string outlives
     // the send). Re-emit to the same group it was sent to (the filter guarantees dest_ip is that group), from
     // the SSDP port, with a freshly reset hop limit (UDA 2.0 default).
-    const auto rewritten = RewriteDialLocation(packet.payload);
-    const auto payload = rewritten
-        ? std::as_bytes(std::span<const char>{*rewritten})
+    const auto rewrite = RewriteDialLocation(packet.payload);
+    if (rewrite.action == DialRewrite::Action::Drop) {
+        return;  // RewriteDialLocation logged the cause
+    }
+    const auto payload = rewrite.action == DialRewrite::Action::ForwardRewritten
+        ? std::as_bytes(std::span<const char>{rewrite.payload})
         : packet.payload;
     if (!source_socket_->SendUdpMulticastDatagram(packet.header.dest, SSDP_PORT, payload, SSDP_TTL)) {
         logger_.Error("Cannot reflect ssdp packet from {} to {}", packet.header.source, packet.header.dest);
@@ -277,9 +281,12 @@ void SsdpReflector::OnUnicastResponse(const Packet& packet) noexcept {
     // Inject the 200 OK to the original searcher from our own source address (no spoofing), addressed to
     // the searcher's captured frame MAC — the split's plain SendUdpDatagram takes that dst MAC. A DIAL
     // response's LOCATION is first rewritten to a minted source_if listener (the string outlives the send).
-    const auto rewritten = RewriteDialLocation(packet.payload);
-    const auto payload = rewritten
-        ? std::as_bytes(std::span<const char>{*rewritten})
+    const auto rewrite = RewriteDialLocation(packet.payload);
+    if (rewrite.action == DialRewrite::Action::Drop) {
+        return;  // RewriteDialLocation logged the cause
+    }
+    const auto payload = rewrite.action == DialRewrite::Action::ForwardRewritten
+        ? std::as_bytes(std::span<const char>{rewrite.payload})
         : packet.payload;
     if (!source_socket_->SendUdpDatagram(session.searcher_mac, session.searcher,
             packet.header.source.port, payload, SSDP_TTL)) {
@@ -303,13 +310,13 @@ bool SsdpReflector::ShouldReflect(const Packet& packet, SsdpMessageKind kind) no
     return *message_kind == kind;
 }
 
-std::optional<std::string> SsdpReflector::RewriteDialLocation(std::span<const std::byte> payload) noexcept {
+SsdpReflector::DialRewrite SsdpReflector::RewriteDialLocation(std::span<const std::byte> payload) noexcept {
     if (!dial_proxy_ || !IsDialServiceMessage(payload)) {
-        return std::nullopt;  // proxy disabled, or not a DIAL service message — forward unchanged
+        return {};  // proxy disabled, or not a DIAL service message — forward unchanged
     }
     const auto location = ParseDialLocationAuthority(payload);
     if (!location) {
-        return std::nullopt;  // a DIAL message with no/unparseable LOCATION: nothing to rewrite
+        return {};  // a DIAL message with no/unparseable LOCATION: nothing to rewrite
     }
     const auto max_age = ParseCacheControlMaxAge(payload);
     const auto reflector_authority = dial_proxy_->EnsureDiscoveryListener(location->endpoint,
@@ -317,16 +324,21 @@ std::optional<std::string> SsdpReflector::RewriteDialLocation(std::span<const st
     if (!reflector_authority) {
         logger_.Info("DIAL: no listener for device {} (cap/bind); forwarding its LOCATION unchanged",
             location->endpoint);
-        return std::nullopt;
+        return {};
     }
     // Splice the reflector authority over exactly the LOCATION's host[:port] span. The port may have been
     // omitted (defaulting to 80), in which case the span covers just the host — the inserted "addr:port"
     // still lands correctly because it replaces that exact text.
     std::string rewritten{reinterpret_cast<const char*>(payload.data()), payload.size()};
     rewritten.replace(location->offset, location->length, std::format("{}", *reflector_authority));
+    if (rewritten.size() > MAX_UDP_PAYLOAD_SIZE) {
+        logger_.Error("DIAL: rewritten LOCATION for {} overflows the {}-byte payload ceiling; dropping the datagram",
+            location->endpoint, MAX_UDP_PAYLOAD_SIZE);
+        return {.action = DialRewrite::Action::Drop};
+    }
     logger_.Debug("DIAL: rewrote device {} LOCATION to reflector listener {}",
         location->endpoint, *reflector_authority);
-    return rewritten;
+    return {.action = DialRewrite::Action::ForwardRewritten, .payload = std::move(rewritten)};
 }
 
 void SsdpReflector::EvictExpired(std::chrono::steady_clock::time_point now) noexcept {

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -163,7 +163,7 @@ void SsdpReflector::OnSourcePacket(const Packet& packet) noexcept {
 
     // One session per (client, group): a retransmit to the same group reuses its session, a new client —
     // or the same client searching a different group (a different reply scope) — gets a fresh one
-    // (reserved port + response capture), built locally so a failed reflect rolls it back via RAII.
+    // (reserved port + response registration), built locally so a failed reflect rolls it back via RAII.
     // Either way the search is reflected once, from the session's reserved port.
     const auto existing_session = std::ranges::find_if(sessions_, [&](const Session& session) {
         return session.searcher == packet.header.source && session.group == packet.header.dest.addr;
@@ -181,7 +181,7 @@ void SsdpReflector::OnSourcePacket(const Packet& packet) noexcept {
     if (!target_socket_->SendUdpMulticastDatagram(packet.header.dest, port,
             packet.payload, SSDP_TTL)) {
         logger_.Error("Cannot reflect M-SEARCH from {} to {}", packet.header.source, packet.header.dest);
-        return;  // a new session's reservation + capture RAII-drop here
+        return;  // a new session's reservation + response registration RAII-drop here
     }
     logger_.Debug("Reflected M-SEARCH from {} on reserved port {} (MX {}s)",
         packet.header.source, port, static_cast<unsigned>(mx));
@@ -221,12 +221,12 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
     if (!reservation) {
         return std::nullopt;  // Create logged the cause
     }
-    // Register the 200-OK capture before the reflect, so a fast responder's reply can't arrive first.
-    auto capture = packet_dispatcher_->Register(*target_socket_,
+    // Make the 200-OK response registration before the reflect, so a fast responder's reply can't arrive first.
+    auto registration = packet_dispatcher_->Register(*target_socket_,
         PacketFilter{.dest_ip = our_address, .dest_port = reservation->Port(), .source_mac = config_mac_},
         CreateDelegate<&SsdpReflector::OnUnicastResponse>(this));
-    if (!capture.IsValid()) {
-        logger_.Error("Cannot reflect M-SEARCH from {}: response-capture registration failed",
+    if (!registration.IsValid()) {
+        logger_.Error("Cannot reflect M-SEARCH from {}: response registration failed",
             packet.header.source);
         return std::nullopt;  // reservation RAII-drops here, freeing the port
     }
@@ -236,7 +236,7 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
         .searcher_mac = packet.header.source_mac,
         .expiry = expiry,
         .reservation = std::move(*reservation),
-        .capture = std::move(capture),
+        .registration = std::move(registration),
     };
 }
 
@@ -268,7 +268,7 @@ void SsdpReflector::OnUnicastResponse(const Packet& packet) noexcept {
             && session.searcher.addr.AddressFamily() == family;
     });
     if (it == sessions_.end()) {
-        // Defensive: the capture is released with its session, so a 200 OK normally only reaches us
+        // Defensive: the registration is released with its session, so a 200 OK normally only reaches us
         // while the session lives. If it's gone, so is the port reservation — nothing is left to
         // suppress the kernel's ICMP unreachable, and there's no searcher to forward to. Drop it.
         return;

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -63,7 +63,7 @@ private:
         MacAddress searcher_mac;
         std::chrono::steady_clock::time_point expiry;
         PortReservation reservation;
-        PacketDispatcher::Registration capture;
+        PacketDispatcher::Registration registration;
     };
 
     [[nodiscard]] bool ValidateConfig(const SsdpConfig& config);
@@ -88,7 +88,7 @@ private:
     // unchanged: proxy disabled, not a DIAL message, no/invalid LOCATION, or the listener mint hit a
     // cap/bind failure (all benign — the original LOCATION still resolves for an on-subnet client).
     [[nodiscard]] std::optional<std::string> RewriteDialLocation(std::span<const std::byte> payload) noexcept;
-    // Reserves a port + registers the 200-OK capture for a new client, returning the session to add
+    // Reserves a port + makes the 200-OK response registration for a new client, returning the session to add
     // (not yet in the table) or nullopt (after logging) if the cap is hit or a step fails.
     [[nodiscard]] std::optional<Session> MakeSession(const Packet& packet,
         std::chrono::steady_clock::time_point expiry);
@@ -99,8 +99,8 @@ private:
 
     LinkSocket* source_socket_;
     LinkSocket* target_socket_;
-    PacketDispatcher* packet_dispatcher_;  // retained so OnSourcePacket can register response captures
-    std::optional<MacAddress> config_mac_;  // device-scoping filter, reused on the response capture
+    PacketDispatcher* packet_dispatcher_;  // retained so OnSourcePacket can make response registrations
+    std::optional<MacAddress> config_mac_;  // device-scoping filter, reused on the response registration
     std::optional<DialProxy> dial_proxy_;  // the DIAL app proxy, engaged only when config.dial (IPv4-only)
     std::vector<Session> sessions_;
     Timer eviction_timer_;  // started only while sessions are in flight (lazy); declared last ->

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -82,12 +82,21 @@ private:
     // SSDP request at all is logged and dropped (it shouldn't appear on the group); a message of the
     // other kind is dropped silently (normal bidirectional traffic).
     [[nodiscard]] bool ShouldReflect(const Packet& packet, SsdpMessageKind kind) noexcept;
+    // RewriteDialLocation's verdict on one datagram.
+    struct DialRewrite {
+        enum class Action : uint8_t { ForwardOriginal, ForwardRewritten, Drop };
+        Action action = Action::ForwardOriginal;
+        std::string payload{};  // set for ForwardRewritten
+    };
+
     // When the DIAL proxy is enabled and `payload` is a DIAL advertisement/response, rewrites its LOCATION
     // authority (the device -> a minted source_if listener) so a source client reaches the device's
-    // description endpoint across the boundary, returning the rewritten bytes. nullopt -> forward `payload`
-    // unchanged: proxy disabled, not a DIAL message, no/invalid LOCATION, or the listener mint hit a
-    // cap/bind failure (all benign — the original LOCATION still resolves for an on-subnet client).
-    [[nodiscard]] std::optional<std::string> RewriteDialLocation(std::span<const std::byte> payload) noexcept;
+    // description endpoint across the boundary. ForwardOriginal covers everything benign: proxy disabled,
+    // not a DIAL message, no/invalid LOCATION, or a listener mint that hit a cap/bind failure (the
+    // original LOCATION still resolves for a routed client). Drop means the rewrite was needed but the
+    // result would overflow MAX_UDP_PAYLOAD_SIZE — forwarding the original would advertise the very
+    // endpoint the rewrite exists to replace.
+    [[nodiscard]] DialRewrite RewriteDialLocation(std::span<const std::byte> payload) noexcept;
     // Reserves a port + makes the 200-OK response registration for a new client, returning the session to add
     // (not yet in the table) or nullopt (after logging) if the cap is hit or a step fails.
     [[nodiscard]] std::optional<Session> MakeSession(const Packet& packet,

--- a/src/reflector/util/stream_buffer.h
+++ b/src/reflector/util/stream_buffer.h
@@ -83,6 +83,10 @@ public:
     // span, so `n` overrunning the free tail is a caller bug, not a runtime (or wire-driven) condition: the
     // count is ours, never the peer's. Assert catches it in Debug/ASan; UB otherwise, like a narrow-contract
     // standard-library access.
+    //
+    // Must follow its ReserveTail() with no other mutating call in between: Consume() and a further
+    // ReserveTail() both compact, moving the live region and invalidating the span, so committing
+    // afterwards would publish whatever stale bytes now sit at the tail into the forwarded stream.
     void Commit(size_t n) noexcept {
         assert(n <= capacity_ - tail_);
         tail_ += n;

--- a/tests/http_message_test.cpp
+++ b/tests/http_message_test.cpp
@@ -94,7 +94,7 @@ struct Driver {
                 return;
             }
             if (r->consumed == 0) {
-                break;  // needs more bytes (an incomplete header)
+                break;  // needs more bytes (an incomplete message)
             }
             out += r->header;
             out += r->body;

--- a/tests/raw_socket_test.cpp
+++ b/tests/raw_socket_test.cpp
@@ -735,6 +735,20 @@ TEST(RawSocketBatchTest, ReceiveDropsBpfTruncatedFrame) {
     });
     EXPECT_NE(output.find("oversized frame"), std::string::npos) << output;
 }
+
+// A frame can be fully captured (datalen == caplen) yet exceed MAX_FRAME_SIZE when the batch
+// buffer is BIOCGBLEN-sized, as in macOS production; the walker drops it at capture like the
+// Linux MSG_TRUNC path does.
+TEST(RawSocketReceiveTest, DropsFullyCapturedFrameLargerThanTheFrameCeiling) {
+    TestCaptureSocket capture{"test", 4 * MAX_FRAME_SIZE};
+    const std::vector<std::byte> frame(MAX_FRAME_SIZE + 1, std::byte{0xff});
+    ASSERT_TRUE(capture.WriteFrame(frame));
+
+    const std::string output = CaptureStdout([&] {
+        EXPECT_FALSE(capture.socket.Receive().has_value());
+    });
+    EXPECT_NE(output.find("oversized frame"), std::string::npos) << output;
+}
 #endif  // !defined(__linux__)
 
 #if defined(__linux__)

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -87,6 +87,23 @@ protected:
             "NTS: ssdp:alive\r\n\r\n");
     }
 
+    // A DIAL advertisement padded to exactly `size` bytes. Its LOCATION names a bare host, so the
+    // rewrite to "127.0.0.1:<ephemeral port>" always grows the datagram whatever port is minted.
+    static std::vector<std::byte> MakeGrowingDialAdvertisement(size_t size) {
+        const std::string_view head =
+            "NOTIFY * HTTP/1.1\r\n"
+            "HOST: 239.255.255.250:1900\r\n"
+            "LOCATION: http://10.0.0.1/dd.xml\r\n"
+            "NT: urn:dial-multiscreen-org:service:dial:1\r\n"
+            "NTS: ssdp:alive\r\n"
+            "X-Pad: ";
+        const std::string_view tail = "\r\n\r\n";
+        std::string payload{head};
+        payload.append(size - head.size() - tail.size(), 'a');
+        payload += tail;
+        return Bytes(payload);
+    }
+
     static std::vector<std::byte> MakeDialResponse() {
         return Bytes(
             "HTTP/1.1 200 OK\r\n"
@@ -1004,6 +1021,31 @@ TEST_F(SsdpReflectorTest, DialAdvertisedMaxAgeExtendsTheListenerGrace) {
     packet_dispatcher.Deliver(target, MakePacket(advertisement, IpAddress::SsdpGroupV4()));
     ASSERT_EQ(source.sent.size(), 2u);
     EXPECT_EQ(AsText(source.sent.back().payload), first);  // same listener reused -> same rewrite
+}
+
+// Forwarding the original would advertise the device address the rewrite exists to replace, so an
+// overflowing rewrite drops the datagram instead.
+TEST_F(SsdpReflectorTest, DialDropsAnAdvertisementWhoseRewriteOverflowsThePayloadCeiling) {
+    auto config = MakeConfig(AddressFamily::IPv4);
+    config.dial = true;
+    SsdpReflector reflector{packet_dispatcher, source, target, config};
+    ASSERT_TRUE(reflector.IsValid());
+
+    // Already at the ceiling, so any growth overflows.
+    const auto advertisement = MakeGrowingDialAdvertisement(MAX_UDP_PAYLOAD_SIZE);
+    const std::string output = CaptureStdout([&] {
+        packet_dispatcher.Deliver(target, MakePacket(advertisement, IpAddress::SsdpGroupV4()));
+    });
+
+    EXPECT_TRUE(source.sent.empty());
+    EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
+
+    // Room for the growth: the same message is rewritten and forwarded.
+    packet_dispatcher.Deliver(target,
+        MakePacket(MakeGrowingDialAdvertisement(MAX_UDP_PAYLOAD_SIZE - 20), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(source.sent.size(), 1u);
+    const auto text = AsText(source.sent.back().payload);
+    EXPECT_NE(text.find("http://127.0.0.1:"), std::string_view::npos) << text.substr(0, 200);
 }
 
 TEST_F(SsdpReflectorTest, DialRewritesUnicastResponseLocationWhenEnabled) {

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -904,21 +904,29 @@ TEST_F(SsdpReflectorTest, SameSearcherAndGroupReusesOneSession) {
     EXPECT_EQ(RegistrationCount(), base + 1);  // but one shared session
 }
 
-TEST_F(SsdpReflectorTest, LogsDefaultedMxAtInfoWhenSearchHasNoMx) {
-    const ScopedMinLogLevel level{LogLevel::Info};
+TEST_F(SsdpReflectorTest, LogsDefaultedMxAtDebugOnly) {
     SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
     ASSERT_TRUE(reflector.IsValid());
 
-    // A non-conformant M-SEARCH with no MX header: reflected anyway with the default window, and the
-    // fallback flagged at INFO so it is visible in normal operation (the reflect line itself is DEBUG).
     const auto search_no_mx = Bytes(
         "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nST: ssdp:all\r\n\r\n");
-    const std::string output = CaptureStdout([&] {
-        packet_dispatcher.Deliver(source, MakePacket(search_no_mx, IpAddress::SsdpGroupV4()));
-    });
 
-    EXPECT_EQ(target.sent.size(), 1u);  // reflected despite the missing MX
-    EXPECT_NE(output.find("no/invalid MX"), std::string::npos) << output;
+    {
+        const ScopedMinLogLevel level{LogLevel::Info};
+        const std::string output = CaptureStdout([&] {
+            packet_dispatcher.Deliver(source, MakePacket(search_no_mx, IpAddress::SsdpGroupV4()));
+        });
+        EXPECT_EQ(target.sent.size(), 1u);  // reflected despite the missing MX
+        EXPECT_EQ(output.find("no/invalid MX"), std::string::npos) << output;
+    }
+    {
+        const ScopedMinLogLevel level{LogLevel::Debug};
+        const std::string output = CaptureStdout([&] {
+            packet_dispatcher.Deliver(source, MakePacket(search_no_mx, IpAddress::SsdpGroupV4()));
+        });
+        EXPECT_EQ(target.sent.size(), 2u);
+        EXPECT_NE(output.find("no/invalid MX"), std::string::npos) << output;
+    }
 }
 
 TEST_F(SsdpReflectorTest, DoesNotInfoLogWhenMxIsPresent) {

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -580,7 +580,7 @@ TEST_F(SsdpReflectorTest, LogsErrorWhenSendFails) {
     });
 
     EXPECT_TRUE(target.sent.empty());
-    EXPECT_EQ(RegistrationCount(), base);  // the response capture is rolled back on the failed reflect
+    EXPECT_EQ(RegistrationCount(), base);  // the response registration is rolled back on the failed reflect
     EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
 }
 
@@ -634,7 +634,7 @@ TEST_F(SsdpReflectorTest, MSearchReflectionOriginatesFromAReservedPortAndCreates
     EXPECT_NE(sent.src_port, SSDP_PORT);  // reflected from the reserved ephemeral port, not 1900
     EXPECT_NE(sent.src_port, 0u);
     EXPECT_EQ(sent.ttl, 2);
-    EXPECT_EQ(RegistrationCount(), before + 1);  // + the session's response capture
+    EXPECT_EQ(RegistrationCount(), before + 1);  // + the session's response registration
 }
 
 TEST_F(SsdpReflectorTest, DoesNotReflectMSearchWhenTargetHasNoSourceAddress) {
@@ -652,11 +652,11 @@ TEST_F(SsdpReflectorTest, DoesNotReflectMSearchWhenTargetHasNoSourceAddress) {
     EXPECT_NE(output.find("ERROR"), std::string::npos) << output;
 }
 
-TEST_F(SsdpReflectorTest, DoesNotReflectMSearchWhenResponseCaptureRegistrationFails) {
+TEST_F(SsdpReflectorTest, DoesNotReflectMSearchWhenResponseRegistrationFails) {
     SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
     ASSERT_TRUE(reflector.IsValid());
     const size_t base = RegistrationCount();             // the two multicast registrations
-    packet_dispatcher.fail_register_on_call = base + 1;  // fail the session's response-capture registration
+    packet_dispatcher.fail_register_on_call = base + 1;  // fail the session's response registration
 
     const std::string output = CaptureStdout([&] {
         packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
@@ -753,7 +753,7 @@ TEST_F(SsdpReflectorTest, EvictionTimerKeepsUnexpiredSessions) {
     const size_t base = RegistrationCount();  // multicast registrations only
 
     packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
-    ASSERT_EQ(RegistrationCount(), base + 1);  // + the session's response capture
+    ASSERT_EQ(RegistrationCount(), base + 1);  // + the session's response registration
 
     // MX=2 + 2s grace hasn't elapsed, so firing the eviction timer now keeps the session — and the
     // timer stays armed because the table is still non-empty.
@@ -843,7 +843,7 @@ TEST_F(SsdpReflectorTest, RetransmittedMSearchReusesOneSessionAndReflectsEach) {
     }
 
     EXPECT_EQ(target.sent.size(), 3u);          // reflected every time
-    EXPECT_EQ(RegistrationCount(), base + 1);   // but only one session / response capture
+    EXPECT_EQ(RegistrationCount(), base + 1);   // but only one session / response registration
     const uint16_t port = target.sent.front().src_port;
     EXPECT_NE(port, SSDP_PORT);
     EXPECT_EQ(target.sent[1].src_port, port);   // all reflected from the same reserved port

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -8,6 +8,7 @@
 #include "reflector/mac_address.h"
 #include "reflector/packet.h"
 #include "reflector/packet_dispatcher.h"
+#include "reflector/protocol_constants.h"
 #include "reflector/raw_socket.h"
 #include "reflector/util/narrow_cast.h"
 
@@ -188,12 +189,8 @@ inline bool HasPacketCapturePrivileges() {
     return cached;
 }
 
-// Protocol constants used by the frame helpers below. Kept here so any test that builds
-// or inspects raw Ethernet frames has a single source of truth.
-constexpr uint16_t IPV4_ETHERTYPE = 0x0800;
-constexpr uint16_t IPV6_ETHERTYPE = 0x86dd;
+// Test-only protocol constants; the shared ones come from protocol_constants.h.
 constexpr uint16_t ARP_ETHERTYPE = 0x0806;
-constexpr uint8_t IP_PROTO_UDP = 17;
 constexpr uint8_t IPV6_NEXT_HOPOPT = 0;
 
 inline void AppendBytes(std::vector<std::byte>& out, std::span<const std::byte> bytes) {
@@ -301,8 +298,9 @@ struct TestCaptureSocket {
     FakeInterface iface;
     RawSocket socket;
 
-    explicit TestCaptureSocket(std::string_view interface = "test")
-            : iface{interface, 0, {}}, socket{MakeSocket()} {}
+    explicit TestCaptureSocket(std::string_view interface = "test",
+        size_t receive_buffer_size = MAX_FRAME_SIZE)
+            : iface{interface, 0, {}}, socket{MakeSocket(receive_buffer_size)} {}
 
     TestCaptureSocket(const TestCaptureSocket&) = delete;
     TestCaptureSocket& operator=(const TestCaptureSocket&) = delete;
@@ -343,7 +341,7 @@ struct TestCaptureSocket {
 #endif
 
 private:
-    RawSocket MakeSocket() {
+    RawSocket MakeSocket(size_t receive_buffer_size) {
         int fds[2];
         if (::socketpair(AF_UNIX, SOCK_DGRAM, 0, fds) != 0) {
             ADD_FAILURE() << "socketpair() failed: " << std::strerror(errno);
@@ -362,7 +360,7 @@ private:
             return RawSocket::ForTesting(iface, -1);
         }
         write_fd = fds[1];
-        return RawSocket::ForTesting(iface, fds[0]);
+        return RawSocket::ForTesting(iface, fds[0], receive_buffer_size);
     }
 
     static std::vector<std::byte> EncodeFrame(std::span<const std::byte> frame) {


### PR DESCRIPTION
Four independent fixes, one commit each.

- **MX log level** — the defaulted-MX fallback fires on every M-SEARCH including retransmits, so one non-conformant client floods the default level. Moved to debug.
- **Frame ceiling on the BPF path** — Linux's `recv(MSG_TRUNC)` already surfaces oversized frames for the drop, but the BPF path reads into a BIOCGBLEN-sized batch and happily delivered a fully-captured frame the send path could never re-emit. The former send/receive size constants (both 4 KiB, same rationale) merge into one `MAX_FRAME_SIZE`.
- **Framing comments + naming** — `consumed == 0` also happens mid-body when a chunk-size line splits across reads, which three comments denied; `StreamBuffer::Commit`'s no-interleaved-mutation contract is now stated; the per-session `Registration` was called `capture`, which is also what the sockets it registers on are called.
- **DIAL rewrite ceiling** — a rewrite that grows the datagram past what the send path can frame used to fail deep in the frame builder. Now capped at the rewrite against `MAX_UDP_PAYLOAD_SIZE` and dropped: forwarding the original would advertise the device address the rewrite exists to replace.

Native (888) and docker/Linux (875) unit suites green. The DIAL cap and the BPF ceiling were each verified to fail their test when the guard is stubbed out.