### PR TITLE
refactor: build the DIAL LOCATION rewrite in a reusable scratch buffer

### DIFF
--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -7,10 +7,12 @@
 #include "util/delegate.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <format>
 #include <span>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace {
@@ -80,6 +82,7 @@ void SsdpReflector::Initialize(const SsdpConfig& config) {
         dial_proxy_.emplace(packet_dispatcher_->UnderlyingDispatcher(), source_socket_->GetInterface(),
             target_socket_->GetInterface(),
             std::format("DialProxy:{}:{}->{}", config.name, config.source_if, config.target_if));
+        rewrite_scratch_.reserve(MAX_UDP_PAYLOAD_SIZE);
     }
 
     valid_ = true;
@@ -326,19 +329,33 @@ SsdpReflector::DialRewrite SsdpReflector::RewriteDialLocation(std::span<const st
             location->endpoint);
         return {};
     }
-    // Splice the reflector authority over exactly the LOCATION's host[:port] span. The port may have been
-    // omitted (defaulting to 80), in which case the span covers just the host — the inserted "addr:port"
-    // still lands correctly because it replaces that exact text.
-    std::string rewritten{reinterpret_cast<const char*>(payload.data()), payload.size()};
-    rewritten.replace(location->offset, location->length, std::format("{}", *reflector_authority));
-    if (rewritten.size() > MAX_UDP_PAYLOAD_SIZE) {
+    // Wide enough for a bracketed IPv6 authority, so the format never truncates.
+    std::array<char, 64> authority_text{};
+    const auto formatted = std::format_to_n(authority_text.data(), authority_text.size(), "{}",
+        *reflector_authority);
+    const std::string_view authority{authority_text.data(),
+        static_cast<size_t>(formatted.out - authority_text.data())};
+
+    // Size the result before building: an overflow is rejected without copying, and the splice below
+    // fits the reserved scratch by construction.
+    const std::string_view original{reinterpret_cast<const char*>(payload.data()), payload.size()};
+    const size_t rewritten_size = original.size() - location->length + authority.size();
+    if (rewritten_size > MAX_UDP_PAYLOAD_SIZE) {
         logger_.Error("DIAL: rewritten LOCATION for {} overflows the {}-byte payload ceiling; dropping the datagram",
             location->endpoint, MAX_UDP_PAYLOAD_SIZE);
         return {.action = DialRewrite::Action::Drop};
     }
+    // Splice the reflector authority over exactly the LOCATION's host[:port] span. The port may have been
+    // omitted (defaulting to 80), in which case the span covers just the host — the inserted "addr:port"
+    // still lands correctly because it replaces that exact text.
+    rewrite_scratch_.clear();
+    rewrite_scratch_ += original.substr(0, location->offset);
+    rewrite_scratch_ += authority;
+    rewrite_scratch_ += original.substr(location->offset + location->length);
+
     logger_.Debug("DIAL: rewrote device {} LOCATION to reflector listener {}",
         location->endpoint, *reflector_authority);
-    return {.action = DialRewrite::Action::ForwardRewritten, .payload = std::move(rewritten)};
+    return {.action = DialRewrite::Action::ForwardRewritten, .payload = rewrite_scratch_};
 }
 
 void SsdpReflector::EvictExpired(std::chrono::steady_clock::time_point now) noexcept {

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -86,7 +86,9 @@ private:
     struct DialRewrite {
         enum class Action : uint8_t { ForwardOriginal, ForwardRewritten, Drop };
         Action action = Action::ForwardOriginal;
-        std::string payload{};  // set for ForwardRewritten
+        // ForwardRewritten only: a view into rewrite_scratch_, valid until the next rewrite. Both
+        // callers send it before returning, so nothing outlives it.
+        std::string_view payload{};
     };
 
     // When the DIAL proxy is enabled and `payload` is a DIAL advertisement/response, rewrites its LOCATION
@@ -111,6 +113,7 @@ private:
     PacketDispatcher* packet_dispatcher_;  // retained so OnSourcePacket can make response registrations
     std::optional<MacAddress> config_mac_;  // device-scoping filter, reused on the response registration
     std::optional<DialProxy> dial_proxy_;  // the DIAL app proxy, engaged only when config.dial (IPv4-only)
+    std::string rewrite_scratch_;  // reserved to MAX_UDP_PAYLOAD_SIZE when DIAL is on, so a rewrite never allocates
     std::vector<Session> sessions_;
     Timer eviction_timer_;  // started only while sessions are in flight (lazy); declared last ->
                             // destroyed first (stops before the sessions it sweeps drop)

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -1048,6 +1048,27 @@ TEST_F(SsdpReflectorTest, DialDropsAnAdvertisementWhoseRewriteOverflowsThePayloa
     EXPECT_NE(text.find("http://127.0.0.1:"), std::string_view::npos) << text.substr(0, 200);
 }
 
+// The rewrite scratch is reused across datagrams, so a short rewrite following a long one must not
+// carry its predecessor's tail.
+TEST_F(SsdpReflectorTest, DialRewriteDoesNotLeakThePreviousDatagram) {
+    auto config = MakeConfig(AddressFamily::IPv4);
+    config.dial = true;
+    SsdpReflector reflector{packet_dispatcher, source, target, config};
+    ASSERT_TRUE(reflector.IsValid());
+
+    packet_dispatcher.Deliver(target,
+        MakePacket(MakeGrowingDialAdvertisement(MAX_UDP_PAYLOAD_SIZE - 20), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(source.sent.size(), 1u);
+
+    const auto small = MakeDialAdvertisement();
+    packet_dispatcher.Deliver(target, MakePacket(small, IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(source.sent.size(), 2u);
+
+    const auto text = AsText(source.sent.back().payload);
+    EXPECT_LT(text.size(), small.size() + 32);  // ~4 KiB would mean the predecessor's bytes came along
+    EXPECT_TRUE(text.ends_with("NTS: ssdp:alive\r\n\r\n")) << text;
+}
+
 TEST_F(SsdpReflectorTest, DialRewritesUnicastResponseLocationWhenEnabled) {
     auto config = MakeConfig(AddressFamily::IPv4);
     config.dial = true;


### PR DESCRIPTION
The LOCATION rewrite allocated a fresh ~4 KiB string per rewritten datagram, on the packet path. It now builds into a scratch reserved once to `MAX_UDP_PAYLOAD_SIZE`.

The rewritten size is computed up front from the payload length, the spliced span and the formatted authority, so the overflow check rejects without copying and the splice that follows fits the reserved scratch by construction — the previous order built the string first, which in the overflow case would have reallocated past the reserve, exactly where it matters. The authority itself is formatted into a stack array, so the replacement text doesn't allocate either.

`DialRewrite` carries a view into the scratch; both callers send it before returning.

Native (889), docker/Linux (876) and e2e (33 cases) green. The new test covers the reused buffer's real risk — a stale tail from a longer predecessor — and was verified to fail when the reset is suppressed, while the other DIAL rewrite tests still pass (their payloads are similar lengths).