### PR TITLE
refactor: format log records without allocating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 - Pin Docker base images as `image:tag@sha256:digest` (don't drop the tag).
 - `auto`/`auto&`/`auto*` for locals and loop vars where the initializer makes the type clear; CTAD for aggregates (`std::array parts{a, b}`). Explicit type only when it genuinely clarifies (non-obvious conversion, pinning an interface).
 - Order struct members so padding lands at the end — place a trailing `bool` after a member with tail padding so it tucks in. A throwaway `static_assert(sizeof(X) == 0)` prints the actual size.
+- Mixed signed/unsigned comparison: `static_cast` when non-negativity is evident at the call site (a length, a count); `std::cmp_*` only when a side can actually be negative (an error-signalling `-1`, a difference).
 - Log level by failure, not blame: failure of an intended operation → `Error`, even if externally caused; deliberate skips (traffic not handled by design) → `Debug`. If Error volume becomes a problem, rate-limit — don't downgrade.
 
 ## Build

--- a/src/reflector/logger.h
+++ b/src/reflector/logger.h
@@ -2,12 +2,12 @@
 
 #include "reflector/util/no_copy.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <ctime>
 #include <format>
-#include <print>
 #include <source_location>
 #include <string>
 #include <string_view>
@@ -110,10 +110,27 @@ public:
             localtime_r(&time, &tm_buf);
             char time_str[sizeof("yyyy-mm-dd hh:mm:ss")];
             std::strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", &tm_buf);
-            std::println("{} {} [{}] {} ({}:{})",
-                time_str, level, name_,
-                std::format(std::move(fmt.fmt), std::forward<Args>(args)...),
+
+            // Two buffers, so an over-long message loses its own tail rather than the source
+            // location after it. std::format plus std::println would allocate twice per record.
+            std::array<char, MAX_MESSAGE_SIZE> message_buffer;
+            const auto formatted = std::format_to_n(message_buffer.data(), message_buffer.size(),
+                std::move(fmt.fmt), std::forward<Args>(args)...);
+            const std::string_view message{message_buffer.data(),
+                static_cast<size_t>(formatted.out - message_buffer.data())};
+            // formatted.size is the length the message needed, not what fit, so this catches a cut.
+            const std::string_view elision =
+                static_cast<size_t>(formatted.size) > message_buffer.size() ? "[...]" : "";
+
+            // One slot is held back for the newline, so it lands even on a truncated record and the
+            // whole line still goes out in a single write.
+            std::array<char, MAX_RECORD_SIZE> record;
+            const auto emitted = std::format_to_n(record.data(), record.size() - 1, "{} {} [{}] {}{} ({}:{})",
+                time_str, level, name_, message, elision,
                 detail::Basename(fmt.loc.file_name()), fmt.loc.line());
+            const auto length = static_cast<size_t>(emitted.out - record.data());
+            record[length] = '\n';
+            std::fwrite(record.data(), 1, length + 1, stdout);
         } catch (...) {
             std::fputs("logger: failed to emit message\n", stderr);
         }
@@ -140,6 +157,10 @@ public:
     }
 
 private:
+    static constexpr size_t MAX_MESSAGE_SIZE = 1024;
+    // Plus the timestamp, level, logger name and source location wrapped around it.
+    static constexpr size_t MAX_RECORD_SIZE = MAX_MESSAGE_SIZE + 512;
+
     void ResetName() noexcept {
         owned_name_.clear();
         name_ = {};

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -181,4 +181,38 @@ TEST(LoggerTest, LogLineIncludesSourceLocation) {
     EXPECT_GT(line, 0) << output;
 }
 
+TEST(LoggerTest, MarksAnOverlongMessageAndKeepsWhatFollowsIt) {
+    const ScopedMinLogLevel level{LogLevel::Info};
+    Logger logger{"LoggerTest"};
+
+    // Longer than any record buffer, so the message is cut wherever that boundary sits.
+    const std::string argument(8192, 'x');
+    const std::string output = CaptureStdout([&] {
+        logger.Info("{}", argument);
+    });
+
+    // The marker and the source location both land past the cut message, so the tail is what
+    // explains a failure here.
+    ASSERT_GT(output.size(), 100u);
+    const std::string tail = output.substr(output.size() - 100);
+
+    EXPECT_LT(output.size(), argument.size());  // cut, not grown to fit
+    EXPECT_NE(output.find("[...]"), std::string::npos) << tail;
+    EXPECT_NE(output.find("logger_test.cpp:"), std::string::npos) << tail;
+    EXPECT_TRUE(output.ends_with("\n")) << tail;
+}
+
+TEST(LoggerTest, EndsTheLineWhenEvenTheRecordIsTruncated) {
+    const ScopedMinLogLevel level{LogLevel::Info};
+    Logger logger{std::string(8192, 'n')};  // the name alone overruns the record buffer
+
+    const std::string output = CaptureStdout([&] {
+        logger.Info("a message");
+    });
+
+    // Exactly one newline, at the very end: the reserved slot held, and the record is a single line.
+    ASSERT_FALSE(output.empty());
+    EXPECT_EQ(output.find('\n'), output.size() - 1);
+}
+
 }  // namespace reflector


### PR DESCRIPTION
Every emitted record allocated twice — `std::format` built a string for the message, `std::println` another for the line. Both now format into stack buffers and go out in one `fwrite`. Suppressed records were already free (the level gate runs first), so this is about the lines that do emit, which at Info includes per-packet paths.

Two details worth a look:

- **Separate message buffer.** With a single buffer an over-long message would eat the `(file:line)` suffix — losing the source location exactly when it is most wanted. Splitting them means the message loses its own tail instead, and it is marked `[...]` rather than cut silently.
- **The record buffer holds back its last slot** for the newline, so a truncated record still ends its line and the whole thing is still one write. ASan confirms the reservation is load-bearing: dropping the `- 1` yields a stack-buffer-overflow, caught by the new record-truncation test.

Scope: this does not make logging allocation-free. `IpAddress::ToString` and `MacAddress::ToString` still allocate inside their formatters (a MAC is 17 chars, past SSO, so every time). Removing those needs a non-allocating conversion on the types themselves — tracked as follow-up.

Also carries the signed/unsigned comparison convention this review settled, as its own commit.

Native (891) and docker/Linux (878) green.