### PR TITLE
refactor: convert IP addresses to text without allocating

### DIFF
--- a/src/reflector/ip_address.cpp
+++ b/src/reflector/ip_address.cpp
@@ -220,31 +220,19 @@ socklen_t IpAddress::ToSockaddr(sockaddr_storage& storage, uint16_t port, unsign
     std::unreachable();
 }
 
-std::string IpAddress::ToString() const {
-    int address_family = 0;
-    size_t buffer_size = 0;
-    switch (family_) {
-    using enum Family;
-    case V4:
-        address_family = AF_INET;
-        buffer_size = INET_ADDRSTRLEN;
-        break;
-    case V6:
-        address_family = AF_INET6;
-        buffer_size = INET6_ADDRSTRLEN;
-        break;
-    }
-
-    std::string result;
-    result.resize(buffer_size);
-    if (inet_ntop(address_family, bytes_.data(), result.data(),
-            narrow_cast<socklen_t>(result.size())) == nullptr) {
+std::string_view IpAddress::ToChars(TextBuffer& buffer) const noexcept {
+    const int address_family = family_ == Family::V6 ? AF_INET6 : AF_INET;
+    if (inet_ntop(address_family, bytes_.data(), buffer.data(),
+            narrow_cast<socklen_t>(buffer.size())) == nullptr) {
         GetLogger().Error("Cannot convert IP address to string: {}", Error::FromErrno());
         return "<invalid_ip>";
     }
+    return {buffer.data(), std::char_traits<char>::length(buffer.data())};
+}
 
-    result.resize(std::char_traits<char>::length(result.c_str()));
-    return result;
+std::string IpAddress::ToString() const {
+    TextBuffer buffer;
+    return std::string{ToChars(buffer)};
 }
 
 } // namespace reflector

--- a/src/reflector/ip_address.h
+++ b/src/reflector/ip_address.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 namespace reflector {
@@ -90,6 +91,16 @@ public:
     // pass their interface index unconditionally. Ignored for IPv4.
     socklen_t ToSockaddr(sockaddr_storage& storage, uint16_t port, unsigned scope_id = 0) const noexcept;
 
+    // Scratch for ToChars. The longest form is the mixed one, six hex groups then a dotted quad
+    // ("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:255.255.255.255"), which INET6_ADDRSTRLEN covers with its NUL.
+    using TextBuffer = std::array<char, INET6_ADDRSTRLEN>;
+
+    // The presentation form, written into `buffer` and returned as a view of it — the formatter's
+    // path, which allocates nothing. Yields "<invalid_ip>" (a view of a literal) if conversion fails.
+    [[nodiscard]] std::string_view ToChars(TextBuffer& buffer) const noexcept;
+
+    // The same text, owned. Prefer formatting the address directly; this is for callers that need
+    // a string to keep.
     [[nodiscard]] std::string ToString() const;
 
     [[nodiscard]] bool operator==(const IpAddress&) const noexcept = default;
@@ -138,10 +149,12 @@ struct std::formatter<reflector::IpAddress, char>
 
     template <typename FmtContext>
     FmtContext::iterator format(const reflector::IpAddress& address, FmtContext& ctx) const {
+        reflector::IpAddress::TextBuffer buffer;
+        const auto text = address.ToChars(buffer);
         if (address.IsV6()) {
-            return std::format_to(ctx.out(), "[{}]", address.ToString());
+            return std::format_to(ctx.out(), "[{}]", text);
         }
-        return std::format_to(ctx.out(), "{}", address.ToString());
+        return std::format_to(ctx.out(), "{}", text);
     }
 };
 

--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -353,7 +353,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
     const auto source = interface_->SourceAddressFor(dst.addr);
     if (!source) {
         logger_.Error("Cannot send to {}: interface has no source address for that family",
-            dst.addr.ToString());
+            dst.addr);
         return false;
     }
 
@@ -367,7 +367,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
         : BuildUdpFrame(dst_mac, interface_->Mac(), IpEndpoint{*source, src_port}, dst, payload, ttl, frame);
 #endif
     if (length == 0) {
-        logger_.Error("Cannot build egress frame for {} ({}-byte payload)", dst.addr.ToString(),
+        logger_.Error("Cannot build egress frame for {} ({}-byte payload)", dst.addr,
             payload.size());
         return false;
     }
@@ -384,7 +384,7 @@ bool RawSocket::SendFrame(MacAddress dst_mac, const IpEndpoint& dst, uint16_t sr
     const auto sent = write(fd_.Get(), frame.data(), length);
 #endif
     if (sent < 0 || static_cast<size_t>(sent) != length) {
-        logger_.Error("Cannot inject datagram to {}: {}", dst.addr.ToString(), Error::FromErrno());
+        logger_.Error("Cannot inject datagram to {}: {}", dst.addr, Error::FromErrno());
         return false;
     }
     return true;
@@ -406,7 +406,7 @@ LinkSocket::MulticastMembership RawSocket::JoinMulticastGroup(const IpAddress& g
     if (opened_now) {
         join_fd.Reset(socket(v6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0));
         if (!join_fd.IsValid()) {
-            logger_.Error("Cannot open multicast-join socket for {}: {}", group.ToString(), Error::FromErrno());
+            logger_.Error("Cannot open multicast-join socket for {}: {}", group, Error::FromErrno());
             return {};
         }
     }
@@ -421,7 +421,7 @@ LinkSocket::MulticastMembership RawSocket::JoinMulticastGroup(const IpAddress& g
 
     const int level = v6 ? IPPROTO_IPV6 : IPPROTO_IP;
     if (setsockopt(join_fd.Get(), level, MCAST_JOIN_GROUP, &request, sizeof(request)) != 0) {
-        logger_.Error("Cannot join multicast group {}: {}", group.ToString(), Error::FromErrno());
+        logger_.Error("Cannot join multicast group {}: {}", group, Error::FromErrno());
         if (opened_now) {
             join_fd.Reset();  // the fd we just opened holds no membership; drop it
         }
@@ -429,7 +429,7 @@ LinkSocket::MulticastMembership RawSocket::JoinMulticastGroup(const IpAddress& g
     }
 
     memberships.emplace(group, 1);
-    logger_.Debug("Joined multicast group {} (interface index {})", group.ToString(), interface_->Index());
+    logger_.Debug("Joined multicast group {} (interface index {})", group, interface_->Index());
     return MakeMembership(group);
 }
 
@@ -450,7 +450,7 @@ bool RawSocket::Unregister(const IpAddress& group) noexcept {
         // Invariant: a live membership keeps its family's join fd open (it's closed only here, once
         // the family's last group leaves). An invalid fd with a membership still outstanding is a
         // bug in this bookkeeping, not a runtime condition.
-        logger_.Error("Cannot leave multicast group {}: its join fd is already closed", group.ToString());
+        logger_.Error("Cannot leave multicast group {}: its join fd is already closed", group);
         return true;
     }
 
@@ -462,9 +462,9 @@ bool RawSocket::Unregister(const IpAddress& group) noexcept {
     // us, so a later leave fails with the group already gone — the intended end state (not joined)
     // is reached either way, so this is Debug, not Error.
     if (setsockopt(join_fd.Get(), level, MCAST_LEAVE_GROUP, &request, sizeof(request)) != 0) {
-        logger_.Debug("Leave of multicast group {} did not apply: {}", group.ToString(), Error::FromErrno());
+        logger_.Debug("Leave of multicast group {} did not apply: {}", group, Error::FromErrno());
     } else {
-        logger_.Debug("Left multicast group {}", group.ToString());
+        logger_.Debug("Left multicast group {}", group);
     }
 
     // The family's last group is gone, so free its join fd instead of carrying it for the socket's

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(reflector_test
     ${CMAKE_CURRENT_SOURCE_DIR}/raw_socket_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/stream_buffer_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tcp_socket_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/allocation_counter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util/udp_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/udp_socket_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wol_reflector_test.cpp

--- a/tests/ip_address_test.cpp
+++ b/tests/ip_address_test.cpp
@@ -35,6 +35,17 @@ TEST(IpAddressTest, AnyV4AndAnyV6AreFamilyWildcards) {
     EXPECT_NE(IpAddress::AnyV4(), IpAddress::AnyV6());
 }
 
+TEST(IpAddressTest, ToCharsWritesIntoTheCallersBuffer) {
+    const auto v6 = *IpAddress::FromString("ff02::c");
+    IpAddress::TextBuffer buffer;
+
+    const auto text = v6.ToChars(buffer);
+
+    EXPECT_EQ(text, "ff02::c");
+    EXPECT_EQ(text.data(), buffer.data());  // a view of the buffer, not of anything temporary
+    EXPECT_EQ(IpAddress::FromV4Bytes(192, 0, 2, 1).ToChars(buffer), "192.0.2.1");
+}
+
 TEST(IpAddressTest, IsV4AndIsV6AreMutuallyExclusive) {
     const auto v4 = IpAddress::FromV4Bytes(192, 0, 2, 1);
     EXPECT_TRUE(v4.IsV4());

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -3,6 +3,10 @@
 #include <gtest/gtest.h>
 
 #include "test_helpers.h"
+#include "util/allocation_counter.h"
+
+#include "reflector/ip_address.h"
+#include "reflector/mac_address.h"
 
 #include <charconv>
 #include <format>
@@ -201,6 +205,30 @@ TEST(LoggerTest, MarksAnOverlongMessageAndKeepsWhatFollowsIt) {
     EXPECT_NE(output.find("logger_test.cpp:"), std::string::npos) << tail;
     EXPECT_TRUE(output.ends_with("\n")) << tail;
 }
+
+#if defined(REFLECTOR_HAS_ALLOCATION_COUNTER)
+// Emitting a record stays off the heap end to end: the message and the record format into stack
+// buffers, and the IpAddress/MacAddress formatters write through the same sink rather than building
+// strings. An IPv6 address is the demanding case -- its text is far past any small-string capacity.
+TEST(LoggerTest, EmittingARecordDoesNotAllocate) {
+    const ScopedMinLogLevel level{LogLevel::Info};
+    Logger logger{"LoggerTest"};
+    const auto address = *IpAddress::FromString("2001:db8:85a3:1234:5678:8a2e:370:7334");
+    const auto mac = *MacAddress::FromString("aa:bb:cc:dd:ee:ff");
+
+    size_t allocated = 0;
+    const std::string output = CaptureStdout([&] {
+        logger.Info("warm-up: the redirected stream buffers itself on its first write");
+        const ScopedAllocationCounter counter;
+        logger.Info("group {} via {} port {}", address, mac, 1900);
+        allocated = counter.Count();
+    });
+
+    EXPECT_EQ(allocated, 0u);
+    EXPECT_NE(output.find("[2001:db8:85a3:1234:5678:8a2e:370:7334]"), std::string::npos) << output;
+    EXPECT_NE(output.find("AA:BB:CC:DD:EE:FF"), std::string::npos) << output;
+}
+#endif  // REFLECTOR_HAS_ALLOCATION_COUNTER
 
 TEST(LoggerTest, EndsTheLineWhenEvenTheRecordIsTruncated) {
     const ScopedMinLogLevel level{LogLevel::Info};

--- a/tests/util/allocation_counter.cpp
+++ b/tests/util/allocation_counter.cpp
@@ -1,0 +1,51 @@
+#include "allocation_counter.h"
+
+#if defined(REFLECTOR_HAS_ALLOCATION_COUNTER)
+
+#include <cassert>
+
+// Declared here rather than included: the symbol is in the common sanitizer runtime that both
+// clang and gcc ship, but only clang installs <sanitizer/allocator_interface.h>.
+extern "C" int __sanitizer_install_malloc_and_free_hooks(
+    void (*malloc_hook)(const volatile void*, size_t), void (*free_hook)(const volatile void*));
+
+namespace {
+
+// Read and written from the allocator hooks, which run outside normal control flow; plain
+// zero-initialized globals are ready before any of it.
+bool g_counting = false;
+size_t g_allocations = 0;
+
+void OnMalloc(const volatile void*, size_t) {
+    if (g_counting) {
+        ++g_allocations;
+    }
+}
+
+void OnFree(const volatile void*) {}
+
+} // namespace
+
+namespace reflector {
+
+ScopedAllocationCounter::ScopedAllocationCounter() noexcept {
+    // The sanitizer offers no uninstall and only five hook slots, so install once per process and
+    // let g_counting bound the window instead.
+    static const bool installed = __sanitizer_install_malloc_and_free_hooks(&OnMalloc, &OnFree) != 0;
+    assert(installed && "sanitizer malloc hooks unavailable; the count would always read zero");
+
+    g_allocations = 0;
+    g_counting = true;
+}
+
+ScopedAllocationCounter::~ScopedAllocationCounter() noexcept {
+    g_counting = false;
+}
+
+size_t ScopedAllocationCounter::Count() const noexcept {
+    return g_allocations;
+}
+
+} // namespace reflector
+
+#endif  // REFLECTOR_HAS_ALLOCATION_COUNTER

--- a/tests/util/allocation_counter.h
+++ b/tests/util/allocation_counter.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+
+// Counting rides the sanitizer's malloc hooks, so it exists only in sanitized builds. Guard tests
+// with REFLECTOR_HAS_ALLOCATION_COUNTER; the Debug gate always defines it.
+#if defined(__SANITIZE_ADDRESS__)
+#define REFLECTOR_HAS_ALLOCATION_COUNTER 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define REFLECTOR_HAS_ALLOCATION_COUNTER 1
+#endif
+#endif
+
+#if defined(REFLECTOR_HAS_ALLOCATION_COUNTER)
+
+namespace reflector {
+
+// Counts every allocation made while it is alive, so a test can assert that a path stays off the
+// heap. Counting each malloc rather than watching allocated bytes is what catches a transient
+// allocation — a std::string built and destroyed inside the window nets to zero bytes but is
+// exactly the thing worth failing on.
+//
+// Replacing operator new would have to cover every nothrow and aligned overload to avoid
+// mismatching the sanitizer's own, so this hooks the sanitizer's allocator instead. Single
+// threaded, one live counter at a time.
+class ScopedAllocationCounter {
+public:
+    ScopedAllocationCounter() noexcept;
+    ~ScopedAllocationCounter() noexcept;
+
+    ScopedAllocationCounter(const ScopedAllocationCounter&) = delete;
+    ScopedAllocationCounter& operator=(const ScopedAllocationCounter&) = delete;
+
+    [[nodiscard]] size_t Count() const noexcept;
+};
+
+} // namespace reflector
+
+#endif  // REFLECTOR_HAS_ALLOCATION_COUNTER


### PR DESCRIPTION
`IpAddress`'s formatter went through `ToString`, allocating a string per formatted address — including IPv4, which sized its buffer to 16 and stepped just past libstdc++'s small-string capacity. `ToChars` writes into a caller-provided buffer and returns a view of it; `ToString` stays for the one caller that needs an owning string.

Nine `raw_socket` log sites passed `ToString` into a formatter that already handles `IpAddress`, so they pass the address itself now — the rest of the codebase, including the test util, already did. **Behaviour note:** IPv6 prints bracketed in those nine lines as a result (`[ff02::c]`), matching every other site.

`MacAddress` needed no change — it has no `ToString` and its formatter always wrote straight to the output iterator.

## Enforcing it

Three changes now rest on formatting staying off the heap, with nothing checking it. `ScopedAllocationCounter` counts allocations via the sanitizer's malloc hooks. Two earlier designs were discarded for concrete reasons worth recording:

- replacing global `operator new` collided with ASan's own `nothrow`/aligned overloads (`alloc-dealloc-mismatch`, whole suite down);
- watching `__sanitizer_get_current_allocated_bytes` is a **net** figure, so a string built and freed inside the window reads as zero — it passed with the regression deliberately reinstated.

The hook version catches it: 1 allocation with `ToString` restored in the formatter, 0 with `ToChars`. It needs a long IPv6 literal, since `ff02::c` fits libc++'s SSO and never allocated either way.

Sanitizer-gated, so the test is `#if`-guarded to match.

Native (893), docker Debug (880) and docker Release (879, test correctly excluded) all green.