### PR TITLE
Pin that a rebind survives repeated interface recreations

### DIFF
--- a/src/reflector/raw_socket.cpp
+++ b/src/reflector/raw_socket.cpp
@@ -525,14 +525,13 @@ bool RawSocket::RejoinGroups() noexcept {
             continue;
         }
         // A fresh fd rather than a re-join on the old one: where a recreated interface is handed
-        // back the number it had, the kernel still has the old fd down for that (group, index) and
-        // refuses the join as a duplicate — and a membership it keeps for a dead index still counts
-        // against the socket's join cap (Linux igmp_max_memberships, 20 by default, and not
-        // raisable on a locked-down router), so kept sockets would exhaust it after a handful of
-        // recreations. Closed before the reopen rather than after, so the descriptor it frees is
-        // the one the reopen takes: at the process fd limit that is the difference between
-        // recovering and staying deaf. Refcounts are untouched, so the memberships already handed
-        // to reflectors stay valid.
+        // back the number it had, the kernel refuses the duplicate (group, index) join — and a
+        // membership it keeps for a dead index still counts against igmp_max_memberships, so a
+        // kept fd stops joining after 20 recreations (measured; see the recreation-cap test).
+        // Closed before the reopen rather than after, so the descriptor it frees is the one the
+        // reopen takes: at the process fd limit that is the difference between recovering and
+        // staying deaf. Refcounts are untouched, so the memberships already handed to reflectors
+        // stay valid.
         auto& join_fd = join_fds_.Get(family);
         join_fd.Reset();
         join_fd.Reset(socket(family == IpAddress::Family::V6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0));

--- a/tests/raw_socket_test.cpp
+++ b/tests/raw_socket_test.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <arpa/inet.h>
 #include <cstdio>
+#include <cstring>
 #include <cstdlib>
 #include <format>
 #include <fstream>
@@ -1151,6 +1152,32 @@ TEST_F(RawSocketInterfacePairRequiresRootTest, RebindRestoresTheCaptureAfterRecr
     EXPECT_TRUE(socket.Attached());
     EXPECT_EQ(socket.Fd(), fd);  // same fd throughout, so dispatcher registrations survive
 }
+
+#if defined(__linux__)
+// A kept join fd would exhaust the socket's membership cap: a destroyed interface's memberships are
+// not scrubbed from a surviving socket, so every recreation's join adds another. Measured here at
+// the default igmp_max_memberships of 20 -- the 21st join on a kept fd fails with ENOBUFS -- which
+// is why the rebind reopens rather than re-joining in place.
+TEST_F(RawSocketInterfacePairRequiresRootTest, SurvivesRepeatedRecreationsWithoutExhaustingTheJoinCap) {
+    Interface iface{pair.InjectInterface()};
+    ASSERT_TRUE(iface.IsValid());
+    RawSocket socket{iface};
+    ASSERT_TRUE(socket.IsValid());
+    const auto group = IpAddress::MdnsGroupV4();
+    auto membership = socket.JoinMulticastGroup(group);
+    ASSERT_TRUE(membership.IsValid());
+
+    // Comfortably past the cap, so a rebind holding its join fd runs out partway through.
+    for (int i = 0; i < 25; ++i) {
+        ASSERT_TRUE(pair.Recreate()) << "recreation " << i;
+        ASSERT_NE(iface.Reidentify(), Interface::IdentityChange::Parked) << "recreation " << i;
+        ASSERT_TRUE(socket.Rebind()) << "recreation " << i;
+        ASSERT_TRUE(socket.GroupsJoined()) << "recreation " << i;
+    }
+
+    EXPECT_TRUE(KernelHasMembership(pair.InjectInterface(), group));
+}
+#endif
 
 #if defined(__linux__)
 // The capture re-attaching is not enough: without the re-join the socket comes back attached and


### PR DESCRIPTION
The rebind reopens its multicast-join fd rather than re-joining on the existing
one. The comment justified that partly by a claim I had not measured: that
memberships for a destroyed interface keep counting against the socket's cap.

Measured it. With `igmp_max_memberships` at its default 20, joining one group on
one kept socket across successive interface recreations succeeds exactly 20 times
and then fails with `ENOBUFS` — so a destroyed interface's memberships really are
not scrubbed from a surviving socket, and a kept join fd would leave the daemon
permanently unable to join anything after 20 recreations.

That is a stronger reason for the reopen than the duplicate-join refusal, and
nothing pinned it, so this adds the test that does: join a group, then 25
recreate/reidentify/rebind cycles, asserting each rebind succeeds and the socket
still reports its groups joined.

It pins our behaviour rather than the kernel's, deliberately. If a future kernel
starts scrubbing, the test simply passes; if someone decides the reopen looks
wasteful, it fails. Verified it catches that: with the reopen reverted to a
re-join in place it fails at recreation 19 — the initial join plus 19 more being
the cap — with the ENOBUFS in the log.

The comment now cites the measurement and points at the test instead of arguing
the case, which made it shorter.

910 unit tests native (Debug, ASan/UBSan), 899 in docker including 21 root-gated.
