### PR TITLE
Stop building gmock, drop a dead FetchContent option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,8 +211,8 @@ if(BUILD_TESTING)
     FetchContent_Declare(googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG v1.18.0
-        GIT_SHALLOW FALSE  # ensure submodules are checked out
     )
+    set(BUILD_GMOCK OFF)
     FetchContent_MakeAvailable(googletest)
 
     add_subdirectory(tests)


### PR DESCRIPTION
Two build-file removals, prompted by asking whether anything in the build existed
to cope with the pre-1.18 googletest. Nothing did — but two lines were doing
nothing useful.

`BUILD_GMOCK` defaults on, so gmock's translation units were compiled in every
configure and build (native, docker debug/release, valgrind, and the armv7/armv5
cross-builds) and linked by nobody. The suite has zero gmock references: its
`tests/mocks` are fakes that model behaviour — `FakeLinkSocket::Rebind()` sets the
socket attached and its groups joined, `FakeInterface::Reidentify()` implements the
whole identity state machine — so tests assert outcomes rather than call
expectations. Call expectations would pin *how* a repair happens instead of that it
happened, which is the opposite of how this suite is written.

`GIT_SHALLOW FALSE` restated CMake's default (the option is opt-in, adding `--depth 1`),
and its comment credited it with checking out submodules, which it has nothing to do
with — that is `GIT_SUBMODULES`. It dated from the initial commit, so it was never
working around anything.

Verified by purging the fetched dependency and reconfiguring: `googlemock/` no longer
appears in the build tree, where it previously held `gmock-all.cc.o` and `gmock_main`.
910 unit tests native (Debug, ASan/UBSan) and 899 in docker, which builds from a fresh
clone and configure.
