### PR TITLE
Evict state minted against a replaced interface

### DIFF
--- a/src/reflector/application.cpp
+++ b/src/reflector/application.cpp
@@ -180,7 +180,8 @@ bool Application::ReconcileInterfaces(std::span<const unsigned> indexes, bool re
         // proves its interface has not gone anywhere. A rename is the exception — it keeps both
         // the index and the capture, so only the name lookup sees it — but it also announces
         // itself, which is why a requested interface resolves regardless.
-        const bool capturing = socket.Attached() && socket.GroupsJoined();
+        const bool attached = socket.Attached();
+        const bool capturing = attached && socket.GroupsJoined();
         if (capturing && !refresh_requested) {
             continue;
         }
@@ -192,6 +193,14 @@ bool Application::ReconcileInterfaces(std::span<const unsigned> indexes, bool re
         }
         if (change == Interface::IdentityChange::Unchanged && refresh_requested) {
             iface->Refresh();  // Reidentify already refreshed the other cases
+        }
+
+        // Only a detached capture or a moved index means the kernel object itself was replaced;
+        // memberships gone from an attached capture is a failed re-join on a live one, and
+        // evicting state over that would be wrong. A counter rather than a call, so the write
+        // carries none of the ordering the post-loop broadcast has to respect.
+        if (!attached || change == Interface::IdentityChange::Repointed) {
+            iface->MarkReplaced();
         }
 
         // A capture is bound to a kernel object, not to a name, so it does not follow the

--- a/src/reflector/dial_proxy.cpp
+++ b/src/reflector/dial_proxy.cpp
@@ -19,8 +19,8 @@ DialProxy::DialProxy(Dispatcher& dispatcher, const Interface& source_if, const I
     std::string logger_name)
         : logger_{std::move(logger_name)}
         , dispatcher_{&dispatcher}
-        , source_if_{&source_if}
-        , target_if_{&target_if}
+        , source_if_{source_if}
+        , target_if_{target_if}
         , eviction_timer_{dispatcher} {}
 
 std::optional<IpEndpoint> DialProxy::EnsureDiscoveryListener(const IpEndpoint& device,
@@ -32,6 +32,27 @@ std::optional<IpEndpoint> DialProxy::EnsureDiscoveryListener(const IpEndpoint& d
 }
 
 void DialProxy::OnInterfaceChanged() noexcept {
+    // Asymmetric, because a listener binds a source_if address while every upstream is
+    // egress-pinned to target_if: a target replacement costs the connections and leaves the
+    // listeners serving, since the next connect pins the fresh interface on its own.
+    const bool source_replaced = source_if_.TakeReplaced();
+    if (source_replaced || target_if_.TakeReplaced()) {
+        // Connections first: a Connection borrows an Endpoint* and its dtor decrements that
+        // endpoint's active_connections, so erasing an endpoint with one still pinned would dangle
+        // it. Erased outright rather than through Abort's deferred teardown, since this runs from
+        // the reconcile, never with a connection's handler on the stack.
+        const auto connections = connections_.size();
+        connections_.clear();
+        const auto listeners = source_replaced ? endpoints_.size() : 0;
+        if (source_replaced) {
+            endpoints_.clear();
+        }
+        if (connections > 0 || listeners > 0) {
+            logger_.Info("{}_if was replaced; dropped {} connection(s) and {} listener(s)",
+                source_replaced ? "source" : "target", connections, listeners);
+        }
+    }
+
     const auto current = source_if_->SourceAddress(IpAddress::Family::V4);
 
     // A listener is stale when its bind address no longer matches source_if's current V4 source — the
@@ -309,7 +330,7 @@ void DialProxy::OnAccept(int listener_fd) noexcept {
         return;  // the accepted client TcpSocket drops here -> RAII close
     }
 
-    auto upstream = TcpSocket::Connect(ep->device, target_if_);
+    auto upstream = TcpSocket::Connect(ep->device, target_if_.Get());
     if (!upstream) {
         logger_.Error("Dropping accept for {}: failed to start the upstream connect", ep->device);
         return;

--- a/src/reflector/dial_proxy.h
+++ b/src/reflector/dial_proxy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dispatcher.h"
+#include "interface.h"
 #include "http_message.h"
 #include "ip_endpoint.h"
 #include "logger.h"
@@ -18,7 +19,6 @@
 
 namespace reflector {
 
-class Interface;
 
 // The DIAL (DIscovery And Launch) application proxy. A DIAL-capable device (a smart TV) restricts
 // its description/REST endpoints to its own subnet; this proxy mints a per-device TCP listener on the
@@ -214,8 +214,10 @@ private:
 
     Logger logger_;  // "DialProxy:{name}:{src}->{tgt}" — passed in by SsdpReflector
     Dispatcher* dispatcher_;
-    const Interface* source_if_;
-    const Interface* target_if_;
+    // Refs, not pointers: the listeners bind an address on one leg and every upstream is
+    // egress-pinned to the other, so both need to notice a recreation.
+    InterfaceRef source_if_;
+    InterfaceRef target_if_;
 
     // Keyed by the device endpoint via std::hash<IpEndpoint>. Node-stable so a FindEndpointByListenerFd
     // result stays valid across an unrelated mint, and so OnAccept can re-enter EnsureRestListener (which

--- a/src/reflector/interface.h
+++ b/src/reflector/interface.h
@@ -6,9 +6,11 @@
 #include "mac_address.h"
 #include "util/no_move.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace reflector {
 
@@ -66,6 +68,17 @@ public:
     // a new number. Virtual so tests substitute a no-syscall fake.
     virtual IdentityChange Reidentify() noexcept;
 
+    // Which kernel object this interface's name currently denotes. The index cannot stand in: a
+    // recreated interface may be handed back the number it had. Anything minted against the old
+    // object is dead however the replacement resolves, so a holder records this and compares
+    // (see InterfaceRef).
+    [[nodiscard]] uint32_t Generation() const noexcept { return generation_; }
+
+    // Records that this name now denotes a different kernel object. Application is the only
+    // correct caller: the evidence is split between Reidentify's verdict and the capture's
+    // attachment probe, and neither sees it alone on every platform.
+    void MarkReplaced() noexcept { ++generation_; }
+
 protected:
     // Test seam: fixed identity, no kernel lookups (see FakeInterface).
     Interface(std::string_view name, unsigned index, const InterfaceAddresses& addresses) noexcept;
@@ -83,6 +96,34 @@ private:
 
     Logger logger_;
     std::string name_;
+    uint32_t generation_ = 0;
+};
+
+// A borrowed Interface plus the generation the holder last saw it at. Application re-points an
+// Interface rather than replacing it, so a raw pointer stays valid across a recreation and reports
+// nothing about it; the generation is what moves. operator-> leaves ordinary reads unchanged.
+class InterfaceRef {
+public:
+    explicit InterfaceRef(const Interface& interface) noexcept
+            : interface_{&interface}, generation_{interface.Generation()} {}
+
+    const Interface* operator->() const noexcept { return interface_; }
+    const Interface& operator*() const noexcept { return *interface_; }
+    // For the few APIs that take a `const Interface*`; keeping it explicit means storing the bare
+    // pointer somewhere else, and losing the tracking with it, has to be deliberate.
+    [[nodiscard]] const Interface* Get() const noexcept { return interface_; }
+
+    // Whether the kernel object was replaced since this last reported it, consuming the transition
+    // so the next call says false. Check and acknowledge in one step: a separate acknowledgement
+    // would leave a holder that forgot it evicting on every notification forever.
+    [[nodiscard]] bool TakeReplaced() noexcept {
+        const uint32_t current = interface_->Generation();
+        return std::exchange(generation_, current) != current;
+    }
+
+private:
+    const Interface* interface_;
+    uint32_t generation_;
 };
 
 } // namespace reflector

--- a/src/reflector/ssdp_reflector.cpp
+++ b/src/reflector/ssdp_reflector.cpp
@@ -33,6 +33,7 @@ SsdpReflector::SsdpReflector(PacketDispatcher& packet_dispatcher, LinkSocket& so
               target_socket.GetInterface(), FamilyCapability::PolicyOf(config)}
         , source_socket_{&source_socket}
         , target_socket_{&target_socket}
+        , target_if_{target_socket.GetInterface()}
         , packet_dispatcher_{&packet_dispatcher}
         , config_mac_{config.mac}
         , eviction_timer_{packet_dispatcher.UnderlyingDispatcher()} {
@@ -94,6 +95,7 @@ void SsdpReflector::Initialize(const SsdpConfig& config) {
 
 void SsdpReflector::OnInterfaceChanged() noexcept {
     DynamicFamilyReflector::OnInterfaceChanged();  // re-gate families: join/leave groups + (un)register captures
+    EvictStaleSessions();
     if (dial_proxy_) {
         // Drops listeners bound to a now-changed source_if address; the next reflected DIAL advertisement
         // re-mints them lazily (RewriteDialLocation -> EnsureDiscoveryListener), against the fresh address.
@@ -238,6 +240,7 @@ std::optional<SsdpReflector::Session> SsdpReflector::MakeSession(const Packet& p
         .searcher = packet.header.source,
         .group = packet.header.dest.addr,
         .searcher_mac = packet.header.source_mac,
+        .reserved_address = *our_address,
         .expiry = expiry,
         .reservation = std::move(*reservation),
         .registration = std::move(registration),
@@ -356,6 +359,30 @@ SsdpReflector::DialRewrite SsdpReflector::RewriteDialLocation(std::span<const st
     logger_.Debug("DIAL: rewrote device {} LOCATION to reflector listener {}",
         location->endpoint, *reflector_authority);
     return {.action = DialRewrite::Action::ForwardRewritten, .payload = rewrite_scratch_};
+}
+
+void SsdpReflector::EvictStaleSessions() noexcept {
+    // Wholesale, since every session sits on the same target leg.
+    size_t removed = sessions_.size();
+    if (target_if_.TakeReplaced()) {
+        sessions_.clear();
+    } else {
+        // The target kept its identity but may have been re-addressed under the reservations.
+        // Responders reply to the address the search went out from, and the reservation is bound
+        // to it, so a session whose address is gone can never be answered.
+        removed = std::erase_if(sessions_, [this](const Session& session) {
+            const auto current = target_if_->SourceAddressFor(session.group);
+            return !current || *current != session.reserved_address;
+        });
+    }
+
+    if (removed == 0) {
+        return;
+    }
+    logger_.Info("Dropped {} search session(s) whose reserved address on the target is gone", removed);
+    if (sessions_.empty()) {
+        eviction_timer_.Stop();  // nothing left to sweep
+    }
 }
 
 void SsdpReflector::EvictExpired(std::chrono::steady_clock::time_point now) noexcept {

--- a/src/reflector/ssdp_reflector.h
+++ b/src/reflector/ssdp_reflector.h
@@ -61,6 +61,7 @@ private:
         IpEndpoint searcher;
         IpAddress group;
         MacAddress searcher_mac;
+        IpAddress reserved_address;
         std::chrono::steady_clock::time_point expiry;
         PortReservation reservation;
         PacketDispatcher::Registration registration;
@@ -103,6 +104,10 @@ private:
     // (not yet in the table) or nullopt (after logging) if the cap is hit or a step fails.
     [[nodiscard]] std::optional<Session> MakeSession(const Packet& packet,
         std::chrono::steady_clock::time_point expiry);
+    // Drops sessions the target leg can no longer answer on: all of them when its kernel object
+    // was replaced, otherwise those whose reserved address it no longer has.
+    void EvictStaleSessions() noexcept;
+
     // The eviction-timer callback (its signature is the timer's): drops sessions past their expiry.
     // `now` is the reactor's fire-cycle time, which is also the test seam — FakeDispatcher::FireTimers
     // passes it, so expiry is driven without reading the real clock.
@@ -110,6 +115,7 @@ private:
 
     LinkSocket* source_socket_;
     LinkSocket* target_socket_;
+    InterfaceRef target_if_;
     PacketDispatcher* packet_dispatcher_;  // retained so OnSourcePacket can make response registrations
     std::optional<MacAddress> config_mac_;  // device-scoping filter, reused on the response registration
     std::optional<DialProxy> dial_proxy_;  // the DIAL app proxy, engaged only when config.dial (IPv4-only)

--- a/tests/application_test.cpp
+++ b/tests/application_test.cpp
@@ -686,6 +686,38 @@ TEST_F(ApplicationTest, ACaptureReadFailureLeavesAnAttachedCaptureAlone) {
     EXPECT_EQ(dispatcher_->TimerCount(), 1u);  // nothing outstanding, so the retry stands down
 }
 
+// A detached capture means the kernel object itself went.
+TEST_F(ApplicationTest, ReportsAReplacementWhenTheCaptureDetaches) {
+    ConfigureSocket("src", {.interface_index = 5});
+    ConfigureSocket("dst", {.interface_index = 9});
+    auto app = MakeApp();
+    ASSERT_TRUE(app.Configure(TestConfigBuilder{}.Add(MakeWolConfig("tv", "src", "dst", {9})).Build()));
+    const auto before = Iface("src")->Generation();
+    const auto dst_before = Iface("dst")->Generation();
+
+    Socket("src")->attached = false;
+    dispatcher_->FireTimers(std::chrono::steady_clock::now());
+
+    EXPECT_NE(Iface("src")->Generation(), before);
+    EXPECT_EQ(Iface("dst")->Generation(), dst_before);
+}
+
+// Memberships gone from a still-attached capture is a failed re-join on a live interface. It needs
+// repairing, but evicting a reflector's state over it would throw away perfectly good listeners.
+TEST_F(ApplicationTest, DoesNotReportAReplacementWhenOnlyTheGroupsAreGone) {
+    ConfigureSocket("src", {.interface_index = 5});
+    ConfigureSocket("dst", {.interface_index = 9});
+    auto app = MakeApp();
+    ASSERT_TRUE(app.Configure(TestConfigBuilder{}.Add(MakeWolConfig("tv", "src", "dst", {9})).Build()));
+    const auto before = Iface("src")->Generation();
+
+    Socket("src")->groups_joined = false;  // attached stays true
+    dispatcher_->FireTimers(std::chrono::steady_clock::now());
+
+    EXPECT_EQ(Iface("src")->Generation(), before);
+    EXPECT_EQ(Socket("src")->rebinds, 1u);  // still repaired, just not counted as a replacement
+}
+
 TEST_F(ApplicationTest, FailsConfigureWhenTheInterfaceIsInvalid) {
     ConfigureSocket("src", {.interface_valid = false});
     auto app = MakeApp();

--- a/tests/dial_proxy_test.cpp
+++ b/tests/dial_proxy_test.cpp
@@ -471,6 +471,39 @@ TEST_F(DialProxyTest, OnInterfaceChangedDropsListenersBoundToAChangedSourceAddre
     EXPECT_EQ(dispatcher.TimerCount(), 0u);       // nothing left to sweep -> the reaper stopped
 }
 
+// A source_if recreated with the SAME address evicts nothing by the address predicate.
+TEST_F(DialProxyTest, OnInterfaceReplacedDropsEverythingWhenTheSourceIsReplaced) {
+    auto proxy = MakeProxy();
+    ASSERT_TRUE(proxy.EnsureDiscoveryListener(Device(2)).has_value());
+    ASSERT_TRUE(proxy.EnsureDiscoveryListener(Device(3)).has_value());
+    const int fd = ListenerFd(proxy, Device(2));
+    ASSERT_TRUE(dispatcher.IsWatching(fd));
+
+    source_if.MarkReplaced();  // the address is untouched; the kernel object is not
+    proxy.OnInterfaceChanged();
+
+    EXPECT_EQ(EndpointCount(proxy), 0u);
+    EXPECT_EQ(ConnectionCount(proxy), 0u);
+    EXPECT_FALSE(dispatcher.IsWatching(fd));
+    EXPECT_EQ(dispatcher.TimerCount(), 0u);  // nothing left to sweep -> the reaper stopped
+}
+
+// A listener never pins the target, so a target replacement must not cost the client its
+// listener. The next connect pins the fresh target itself, since Connect reads it live.
+TEST_F(DialProxyTest, OnInterfaceReplacedKeepsListenersWhenTheTargetIsReplaced) {
+    auto proxy = MakeProxy();
+    ASSERT_TRUE(proxy.EnsureDiscoveryListener(Device(2)).has_value());
+    const int fd = ListenerFd(proxy, Device(2));
+    ASSERT_TRUE(dispatcher.IsWatching(fd));
+
+    target_if.MarkReplaced();
+    proxy.OnInterfaceChanged();
+
+    EXPECT_EQ(EndpointCount(proxy), 1u);
+    EXPECT_TRUE(dispatcher.IsWatching(fd));
+    EXPECT_EQ(ConnectionCount(proxy), 0u);
+}
+
 // An OnInterfaceChanged that does not actually change source_if's V4 source leaves the listeners untouched —
 // no needless re-mint churn, no dropped in-flight discovery.
 TEST_F(DialProxyTest, OnInterfaceChangedKeepsListenersWhenSourceAddressUnchanged) {

--- a/tests/ssdp_reflector_test.cpp
+++ b/tests/ssdp_reflector_test.cpp
@@ -654,6 +654,66 @@ TEST_F(SsdpReflectorTest, MSearchReflectionOriginatesFromAReservedPortAndCreates
     EXPECT_EQ(RegistrationCount(), before + 1);  // + the session's response registration
 }
 
+// A target recreated under the SAME address strands every session, and the address predicate
+// cannot see it.
+TEST_F(SsdpReflectorTest, DropsSessionsWhenTheTargetIsReplaced) {
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+    packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(RegistrationCount(), base + 1);
+
+    target.iface.MarkReplaced();  // the addresses are untouched; the kernel object is not
+    reflector.OnInterfaceChanged();
+
+    EXPECT_EQ(RegistrationCount(), base);
+}
+
+// Live without any recreation: a re-addressed target can never receive the 200 OK.
+TEST_F(SsdpReflectorTest, DropsSessionsWhenTheTargetIsReAddressed) {
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+    packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(RegistrationCount(), base + 1);
+
+    // A different address, not none: the family stays sendable, so only the session goes.
+    target.iface.SetV4(IpAddress::FromV4Bytes(10, 0, 0, 7));
+    reflector.OnInterfaceChanged();
+
+    EXPECT_EQ(RegistrationCount(), base);
+}
+
+// Nothing in a session is pinned to the source leg, so a change there must not cost the searcher
+// its in-flight discovery.
+TEST_F(SsdpReflectorTest, KeepsSessionsWhenOnlyTheSourceChanges) {
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+    packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(RegistrationCount(), base + 1);
+
+    source.iface.MarkReplaced();
+    source.iface.SetV4(IpAddress::FromV4Bytes(10, 0, 0, 7));
+    reflector.OnInterfaceChanged();
+
+    EXPECT_EQ(RegistrationCount(), base + 1);
+}
+
+// The reconcile broadcasts on every pass, including the quiet backstop tick, so a session must
+// survive one that reports nothing.
+TEST_F(SsdpReflectorTest, KeepsSessionsWhenNothingChanged) {
+    SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
+    ASSERT_TRUE(reflector.IsValid());
+    const size_t base = RegistrationCount();
+    packet_dispatcher.Deliver(source, MakePacket(MakeSearch(), IpAddress::SsdpGroupV4()));
+    ASSERT_EQ(RegistrationCount(), base + 1);
+
+    reflector.OnInterfaceChanged();
+
+    EXPECT_EQ(RegistrationCount(), base + 1);
+}
+
 TEST_F(SsdpReflectorTest, DoesNotReflectMSearchWhenTargetHasNoSourceAddress) {
     SsdpReflector reflector{packet_dispatcher, source, target, MakeConfig(AddressFamily::IPv4)};
     ASSERT_TRUE(reflector.IsValid());


### PR DESCRIPTION
Interface-recreation recovery repaired the capture and its group memberships.
This drops the state that cannot be repaired: bound sockets and egress pins minted
against the interface's old kernel object, which are dead however the replacement
resolves — including when it comes back with the same addresses, where the
address-comparison predicates saw nothing to do.

## How a holder finds out

`Interface` counts replacements, and `InterfaceRef` pairs a borrowed pointer with
the generation its holder last saw. A holder asks (`TakeReplaced()`) rather than
being told.

That was the second design. The first added a `Reflector::OnInterfaceReplaced`
virtual fired from inside the reconcile loop, which meant two notifications with
*different* rules about what a handler may read — the existing broadcast runs after
the loop precisely because handlers read live interface state, and interfaces later
in the pass are not reconciled yet. Pulling removes the difference instead of
documenting it: Application writes a counter mid-loop, holders read it from the
existing post-loop broadcast, and an integer compare carries none of that ordering.
`operator->` keeps every ordinary read unchanged; `Get()` is deliberately explicit
so stashing the bare pointer, and losing the tracking with it, has to be a choice.
`TakeReplaced()` checks and acknowledges in one step, so there is no separate
acknowledgement to forget.

## DIAL proxy

Asymmetric, because a listener binds a `source_if` address while every upstream is
egress-pinned to `target_if`. A source replacement drops connections and listeners;
a target replacement drops connections only and leaves the listeners serving, since
`Connect` reads `target_if` live and the next one pins the fresh interface itself.

A detached capture or a moved index is a replacement. Memberships gone from a
still-attached capture is a failed re-join on a live interface — it needs repairing,
but evicting over it would throw away working listeners.

## Search sessions (a live bug, no recreation required)

`SsdpReflector::OnInterfaceChanged` never touched the session table. A session's
reservation is bound to the target's source address and its response registration
captures on the target's socket, so a target that was merely re-addressed left every
in-flight session holding a port nothing would arrive on until it expired.

A replacement drops them wholesale, since they all sit on the same leg; short of
that, a session goes when the target no longer has the address it reserved — the
address responders reply to. A source-side change leaves them alone.

## Testing

918 unit tests native (Debug, ASan/UBSan), 907 in docker. Each new behaviour was
mutation-checked: suppressing the generation bump fails only the detach test;
dropping listeners on the target leg fails only the target-asymmetry test;
suppressing the session replacement check and the session address predicate each
fail only their own test. Both commits build standalone.
